### PR TITLE
Updated sponsor links, blue alliance links, fixed lines in matches.

### DIFF
--- a/_data/teams.csv
+++ b/_data/teams.csv
@@ -1,233 +1,233 @@
 TeamNumber,TeamName,Website,Youtube,Twitter,Facebook,Instagram,TBA
-1816,"""The Green Machine""",https://edinarobotics.com/,https://www.youtube.com/user/1816EdinaRobotics,https://twitter.com/firstteam1816,https://www.facebook.com/Team-1816-The-Green-Machine-113912638660613/,NA,https://www.thebluealliance.com/1816
-2052,KnightKrawler,https://www.team2052.com/,https://www.youtube.com/user/KK2052,https://twitter.com/team2052,https://www.facebook.com/team2052,https://www.instagram.com/team2052/,https://www.thebluealliance.com/2052
-2129,Ultraviolet,https://www.swrobotics.com/,NA,https://twitter.com/swrobotics,https://www.facebook.com/SW-Robotics-363257017757341/,https://www.instagram.com/swrobotics/,https://www.thebluealliance.com/2129
-2169,KING TeC,https://kingtec2169.com/,https://www.youtube.com/frc2169,https://twitter.com/frc2169,https://www.facebook.com/FRC2169/,https://www.instagram.com/kingtec2169/,https://www.thebluealliance.com/2169
-2175,The Fighting Calculators,https://fightingcalculators.org/,https://www.youtube.com/user/frc2175,https://twitter.com/frc2175,https://www.facebook.com/frc2175/,https://www.instagram.com/fightingcalculators2175/,https://www.thebluealliance.com/2175
-2177,The Robettes,https://www.therobettes.com/,NA,https://twitter.com/therobettes,https://www.facebook.com/therobettes/,https://www.instagram.com/frc2177therobettes/,https://www.thebluealliance.com/2177
-2181,G.E.A.R.S,https://sites.google.com/view/blainefrcteam2181gears,NA,https://twitter.com/frcteam2181,NA,https://www.instagram.com/frcteam2181/,https://www.thebluealliance.com/2181
-2207,Bright Bears,http://www.whitebearlakerobotics.com/,NA,https://twitter.com/Team2207,NA,NA,https://www.thebluealliance.com/2207
-2220,Blue Twilight,http://team2220.org/,https://www.youtube.com/user/Team2220BlueTwilight,https://twitter.com/2220robotics,https://www.facebook.com/Eagan-High-School-First-Robotics-Team-2220-182480911786242/,https://www.instagram.com/2220bluetwilight/,https://www.thebluealliance.com/2220
-2225,R.U.S.T,http://www.first2225.com/,NA,https://twitter.com/Team2225,https://www.facebook.com/RUST2225/,https://www.instagram.com/rust.2225/,https://www.thebluealliance.com/2225
-2227,Tigers,https://sites.google.com/site/fridleyrobotics/home,NA,https://twitter.com/team_2227?lang=en,https://www.facebook.com/TigerRobotics2227/,https://www.instagram.com/fridleytigerrobotics/,https://www.thebluealliance.com/2227
-2232,Deus ex Machina,NA,NA,NA,https://www.facebook.com/FRC2232/,https://www.instagram.com/anoka_frc_2232/?hl=en,https://www.thebluealliance.com/2232
-2239,Technocrats,https://sites.google.com/view/2239/home,NA,https://twitter.com/Team2239,https://www.facebook.com/2239Technocrats/,https://www.instagram.com/frc2239/,https://www.thebluealliance.com/2239
-2264,Trojan Robotics,https://wayzatarobotics2264.com/,NA,NA,https://www.facebook.com/wayzatarobotics,https://www.instagram.com/wayzatarobotics/,https://www.thebluealliance.com/2264
-2450,Wind Chill,NA,NA,NA,https://www.facebook.com/pg/CDHRaiderbots/posts/?ref=page_internal,NA,https://www.thebluealliance.com/2450
-2470,Team BJORG,https://www.team2470.org/,NA,https://twitter.com/teambjorg,https://www.facebook.com/TeamBJORG/,https://www.instagram.com/teambjorg/,https://www.thebluealliance.com/2470
-2472,Centurions,https://sites.google.com/view/team2472robotics/home,https://www.youtube.com/channel/UClgB3Fmbcc9tpoaoolKMHsg,https://twitter.com/team_2472,NA,https://www.instagram.com/2472centurions/,https://www.thebluealliance.com/2472
-2479,Pheonix,NA,NA,NA,NA,NA,https://www.thebluealliance.com/2479
-2480,Roosevelt Robotics,NA,NA,https://twitter.com/rhsrobotics2480,https://www.facebook.com/RooseveltRobotics/,NA,https://www.thebluealliance.com/2480
-2491,NoMythic,http://www.2491nomythic.com/,https://www.youtube.com/user/NoMthic2491,https://twitter.com/2491NoMythic,https://www.facebook.com/2491NoMythic,https://www.instagram.com/2491nomythic/?hl=en,https://www.thebluealliance.com/2491
-2498,BearBotics,NA,NA,NA,NA,https://www.instagram.com/blakebearbotics/,https://www.thebluealliance.com/2498
-2499,Industrial Revolution,NA,NA,https://twitter.com/hibbingfrc,https://www.facebook.com/Hibbing-FRC-Robotics-Team-2499-172934836106391/,https://www.instagram.com/frcteam2499/?hl=en,https://www.thebluealliance.com/2499
-2500,Herobotics,https://herobotics.org/,https://www.youtube.com/user/Herobotics2500,https://twitter.com/FRC2500,https://www.facebook.com/2500Herobotics/,https://www.instagram.com/herobotics2500/,https://www.thebluealliance.com/2500
-2501,Bionic Polars,http://www.team2501.com/,https://www.youtube.com/channel/UCBYnxa-AIjwneKbKdl6bzwQ,https://twitter.com/FRC2501,https://www.facebook.com/team2501,NA,https://www.thebluealliance.com/2501
-2502,Talon Robotics,http://team2502.com/,NA,https://twitter.com/frc2502?lang=en,https://www.facebook.com/team2502/,NA,https://www.thebluealliance.com/2502
-2503,Warrior Robotics,https://sites.google.com/isd181.org/team2503/home,https://www.youtube.com/channel/UC83ddnAHC1JnSCkWlbYsJvg/featured,NA,NA,https://www.instagram.com/team2503wr/?hl=en,https://www.thebluealliance.com/2503
-2508,Armada,https://frc2508.org/,https://www.youtube.com/user/ArmadaRobotics,https://twitter.com/frc2508,https://www.facebook.com/FRC2508/,https://www.instagram.com/frc2508/,https://www.thebluealliance.com/2508
-2509,Tigerbots,https://sites.google.com/a/isd423.org/frc2509/,NA,https://twitter.com/tigerbots2509,https://www.facebook.com/tigerbots2509,NA,https://www.thebluealliance.com/2509
-2511,Cougars,https://lshsrobotics.wixsite.com/cougars-frc,NA,https://twitter.com/frcteam2511,NA,NA,https://www.thebluealliance.com/2511
-2512,Duluth East Daredevils,https://daredevils2512.org/,https://www.youtube.com/channel/UCuZ2AjvVFjU7kajfJTL-5NQ,https://twitter.com/FRC2512,https://www.facebook.com/Daredevils2512/,https://www.instagram.com/frc2512/,https://www.thebluealliance.com/2512
-2513,TERTOLA,NA,NA,NA,NA,NA,https://www.thebluealliance.com/2513
-2515,Marshall Robotics and Engineering,NA,NA,https://twitter.com/frc2515,https://www.facebook.com/frc2515,https://www.instagram.com/frc2515/,https://www.thebluealliance.com/2515
-2518,Spartan Robotics,http://first2518.weebly.com/,https://www.youtube.com/user/FIRSTTeam2518,https://twitter.com/firstteam2518,NA,NA,https://www.thebluealliance.com/2518
-2525,The pHalcons,NA,NA,NA,NA,NA,https://www.thebluealliance.com/2525
-2526,Crimson Robotics,http://www.crimsonrobotics.com/,https://www.youtube.com/channel/UClWmTsYwaLQvqMJO2RCj93g,https://twitter.com/Crimson2526,https://www.facebook.com/Crimson-Robotics-734231373272992/,https://www.instagram.com/crimsonrobotics/,https://www.thebluealliance.com/2526
-2529,The WHO,NA,NA,NA,NA,NA,https://www.thebluealliance.com/2529
-2530,Inconceivable,http://frcteam2530.org/,NA,https://twitter.com/FRCTEAM2530,https://www.facebook.com/FIRSTRobotics2530Inconceivable,https://www.instagram.com/inconceivablemn/,https://www.thebluealliance.com/2530
-2531,RoboHawks,https://robohawks2531.weebly.com/,https://www.youtube.com/user/2531Robohawks,https://twitter.com/2531RoboHawks,NA,https://www.instagram.com/2531robohawks/,https://www.thebluealliance.com/2531
-2532,FLASH Power,http://flashpower2532.weebly.com/,NA,https://twitter.com/frc2532?lang=en,NA,NA,https://www.thebluealliance.com/2532
-2538,The Plaid Pillagers,https://team2538.wordpress.com/,NA,https://twitter.com/plaid_pillagers?lang=en,https://www.facebook.com/inPLAIDorINSANE/,NA,https://www.thebluealliance.com/2538
-2545,Quantum Mechanics,NA,https://www.youtube.com/channel/UCF9E_vcIJ8L-Z0RxSf41hiQ,https://twitter.com/chhs_robotics,https://www.facebook.com/2545-Robotics-CHHS-156135351113173/,NA,https://www.thebluealliance.com/2545
-2549,Millerbots,https://washburnmillerbots.com/,https://www.youtube.com/channel/UCnqfl9RVsy3yAowlyimnb6g,https://twitter.com/whsmillerbots,https://www.facebook.com/millerbots/,https://www.instagram.com/whsmillerbots/?utm_source=ig_profile_share&igshid=1o35qzot8ptnd,https://www.thebluealliance.com/2549
-2574,RoboHuskie,NA,https://www.youtube.com/user/StAnthonyRoboHuskie,https://twitter.com/robohuskie2574,https://www.facebook.com/pg/Robohuskie/about/?ref=page_internal,https://www.instagram.com/robohuskie2574/,https://www.thebluealliance.com/2574
-2606,Irish Robotics,https://sites.google.com/a/apps.district196.org/irish-robotics/home,NA,https://twitter.com/irish_2606,https://www.facebook.com/IrishRobotics/,https://www.instagram.com/irishrobotics/,https://www.thebluealliance.com/2606
-2654,Polar Rams,http://polarrams.com/,NA,https://twitter.com/2654roborams,https://m.facebook.com/PolarRams,https://www.instagram.com/polarramsrm/,https://www.thebluealliance.com/2654
-2667,Knights of the Valley,http://www.team2667.org/,NA,https://twitter.com/FRC2667,https://www.facebook.com/FIRSTTEAM2667/,https://www.instagram.com/frcteam2667/,https://www.thebluealliance.com/2667
-2823,The Automatons,http://www.hprobotics.org/,https://www.youtube.com/user/highland2823,https://twitter.com/hprobotics,https://www.facebook.com/HPRobotics,https://www.instagram.com/hprobotics2823/,https://www.thebluealliance.com/2823
-2825,Roc Robotics,NA,NA,NA,https://www.facebook.com/Team-2825-Roc-Robotics-1541288902856344/,NA,https://www.thebluealliance.com/2825
-2846,FireBears,http://firebears.org/,https://www.youtube.com/c/FirebearsOrg,https://twitter.com/firebears2846,https://www.facebook.com/FireBears2846,https://www.instagram.com/firebears2846/,https://www.thebluealliance.com/2846
-2847,The MegaHertz,https://megahertz-team2847.webs.com/,NA,https://twitter.com/2847Megahertz,https://www.facebook.com/Team2847/,https://www.instagram.com/frc_team2847/,https://www.thebluealliance.com/2847
-2861,Infinity's End,https://sites.google.com/a/lake-city.k12.mn.us/2861-infinity-s-end/,https://www.youtube.com/channel/UCIZDymD5QqjCaBOpJWCW-EA,https://twitter.com/frc2861?lang=en,NA,NA,https://www.thebluealliance.com/2861
-2879,Oriole Robotics,NA,NA,https://twitter.com/frc2879,https://www.facebook.com/FRC2879/,NA,https://www.thebluealliance.com/2879
-2883,F.R.E.D,https://www.team2883.com/,https://www.youtube.com/channel/UCm9tddMsUaVkkfdhB9oLolw/featured,https://twitter.com/teamfred2883,https://www.facebook.com/team2883,https://www.instagram.com/teamfred2883/,https://www.thebluealliance.com/2883
-2957,Knights,NA,NA,NA,NA,NA,https://www.thebluealliance.com/2957
-2977,Sir Lancer Bots,https://lacrescentrobotics.com/,NA,https://twitter.com/sirlancerbots,https://www.facebook.com/sirlancerbots/,https://www.instagram.com/sirlancerbots/,https://www.thebluealliance.com/2977
-2987,Rogue Robotics,https://www.team2987.com/,NA,https://twitter.com/rogue_robotics,https://www.facebook.com/roguerobotics2987/,https://www.instagram.com/roguerobotics/,https://www.thebluealliance.com/2987
-2989,Star Tech,http://team2989.weebly.com/,https://www.youtube.com/channel/UC6jwARmfNxvDXPb6KrPwKoA,https://twitter.com/frcteam2989,NA,NA,https://www.thebluealliance.com/2989
-3007,Robotitans,https://sites.google.com/view/team-3007/home,https://www.youtube.com/channel/UCoPYTR4KwSRjoG-3LHRHtGQ,https://twitter.com/frcteam3007,NA,NA,https://www.thebluealliance.com/3007
-3018,Nordic Storm,https://www.nordicstorm.org/,NA,https://twitter.com/nordicstorm3018,https://www.facebook.com/NordicStorm3018/,NA,https://www.thebluealliance.com/3018
-3023,STARK Industries,http://team3023.org/,NA,https://twitter.com/FRCTeam3023,https://www.facebook.com/FRCTeam3023/,https://www.instagram.com/team3023/,https://www.thebluealliance.com/3023
-3026,Orange Crush Robotics,https://www.orangecrush3026.com/,NA,https://twitter.com/ocr3026?lang=en,https://www.facebook.com/orangecrushrobotics/,https://www.instagram.com/ocr3026/?hl=en,https://www.thebluealliance.com/3026
-3038,ICE,https://sites.google.com/site/team3038ice,https://www.youtube.com/user/ICE3038,https://twitter.com/ice3038,https://www.facebook.com/3038ICE/,https://www.instagram.com/3038i.c.e.robotics/,https://www.thebluealliance.com/3038
-3042,Cobalt Catalysts,https://team3042.weebly.com/,https://www.youtube.com/user/EastviewCobalt,https://twitter.com/Cobalt3042,https://www.facebook.com/Cobalt3042/,https://www.instagram.com/3042_cobalt_catalysts/,https://www.thebluealliance.com/3042
-3054,IceStorm,NA,NA,NA,https://www.facebook.com/CCHSIceStormRobotics3054/,NA,https://www.thebluealliance.com/3054
-3055,Furious George,NA,NA,https://twitter.com/3055george,https://www.facebook.com/FuriousGeorgeTeam3055/,https://www.instagram.com/3055furiousgeorge/,https://www.thebluealliance.com/3055
-3058,AnnDroids,http://www.anndroids3058.com/,NA,https://twitter.com/Anndroids_3058,https://www.facebook.com/mr.roboto.18,https://www.instagram.com/team_3058/,https://www.thebluealliance.com/3058
-3082,Chicken Bot Pie,https://team3082.com/,NA,https://twitter.com/Team3082/,https://www.facebook.com/team3082/,https://www.instagram.com/chickenbotpie/,https://www.thebluealliance.com/3082
-3090,Ramkawks,NA,NA,NA,https://www.facebook.com/Team3090/,NA,https://www.thebluealliance.com/3090
-3100,Lightning Turtles,https://team3100.com/,https://www.youtube.com/channel/UCasCnsLlqfCEV9WlaFmJqGA,https://twitter.com/frc3100,https://www.facebook.com/FRC3100/,https://www.instagram.com/frc_3100/,https://www.thebluealliance.com/3100
-3102,Tech-No-Tigers,https://www.tnt3102.org/,NA,NA,https://www.facebook.com/tnt3102,https://www.instagram.com/tnt3102/,https://www.thebluealliance.com/3102
-3122,The Alluminators,NA,NA,https://twitter.com/frc3122,https://www.facebook.com/frc3122,NA,https://www.thebluealliance.com/3122
-3130,The ERRORs,NA,https://www.youtube.com/user/error3130,https://twitter.com/errors3130,https://www.facebook.com/error3130,https://www.instagram.com/errors3130/,https://www.thebluealliance.com/3130
-3134,The Accelerators,http://clbrobotics.weebly.com/,https://www.youtube.com/channel/UCQUszqXL0Cr8I4wezAbMefA,NA,https://www.facebook.com/acceleratorsandregulators/,NA,https://www.thebluealliance.com/3134
-3184,Blaze Robotics,https://www.blazerobotics.org/,https://www.youtube.com/user/team3184,https://twitter.com/Team3184?lang=en,https://www.facebook.com/BlazeRobotics/,https://www.instagram.com/blazerobotics/,https://www.thebluealliance.com/3184
-3202,KnightBots,https://sites.google.com/site/hardingknightbots/home,NA,NA,https://www.facebook.com/knightbots/,NA,https://www.thebluealliance.com/3202
-3206,Royal T-Wrecks,https://www.whsactivities.org/robotics,https://www.youtube.com/channel/UCcW_rWXi3W02IrdMRdR7EFQ,https://twitter.com/RTWrecks,NA,https://www.instagram.com/frc3206/,https://www.thebluealliance.com/3206
-3212,YME Stingbots,NA,NA,NA,https://www.facebook.com/YME-Stingbots-3212-141313229686050/,NA,https://www.thebluealliance.com/3212
-3244,Granite City Gear Heads,http://www.granitecitygearheads.com/,https://www.youtube.com/user/GearHeads3244,https://twitter.com/gcgearheads,https://www.facebook.com/granitecitygearheads3244,https://www.instagram.com/gcgearheads/,https://www.thebluealliance.com/3244
-3267,Mariner Robotics,NA,NA,NA,https://www.facebook.com/WKHS-Mariner-Robotics-870746146378688/,NA,https://www.thebluealliance.com/3267
-3275,The Regulators,http://clbregulators.weebly.com/,NA,NA,NA,NA,https://www.thebluealliance.com/3275
-3276,ToolCats,https://www.nls.k12.mn.us/Page/2153#calendar4399/20200301/month,NA,NA,NA,NA,https://www.thebluealliance.com/3276
-3277,ProDigi,NA,NA,https://twitter.com/prodigi3277,https://www.facebook.com/Prodigi3277/,https://www.instagram.com/prodigi3277/,https://www.thebluealliance.com/3277
-3278,QWERTY Robotics,http://qwertyrobotics.org,https://www.youtube.com/channel/UC-GtJBg6khOMis0vaetbAbQ,NA,https://www.facebook.com/qwertyrobotics/,NA,https://www.thebluealliance.com/3278
-3291,AU Pirates,https://sites.google.com/apps.district279.org/au-pirates-pc/about/about-us,,https://twitter.com/parkcenterrobot?lang=en,https://www.facebook.com/3291AuPirates/,https://www.instagram.com/aupirates_3291/,https://www.thebluealliance.com/3291
-3293,OtterBots,NA,NA,NA,NA,NA,https://www.thebluealliance.com/3293
-3294,Backwoods Engineers,NA,NA,NA,https://www.facebook.com/backwoodsengineers3294/,,https://www.thebluealliance.com/3294
-3297,Full Metal Jackets,https://perhamyellowjackets.com/teams/2956273/robotics/varsity,NA,NA,NA,NA,https://www.thebluealliance.com/3297
-3298,ArrowBots,NA,NA,NA,https://www.facebook.com/PAS.Robotics.3298/,NA,https://www.thebluealliance.com/3298
-3299,The Warehouse Crew,NA,https://www.youtube.com/channel/UCAGFQAe-CJWn-_6Xs1rYYJw/videos?disable_polymer=1,NA,NA,NA,https://www.thebluealliance.com/3299
-3300,Midwest WARRIORS,https://team3300.wixsite.com/midwestwarriors,NA,NA,NA,NA,https://www.thebluealliance.com/3300
-3313,Mechatronics,http://www.team3313.com,https://www.youtube.com/user/Team3313Mechatronics,https://twitter.com/team3313,https://www.facebook.com/Team3313/,https://www.instagram.com/team3313/,https://www.thebluealliance.com/3313
-3407,Wild Cards,NA,NA,NA,NA,NA,https://www.thebluealliance.com/3407
-3454,Z Bots,NA,NA,NA,NA,NA,https://www.thebluealliance.com/3454
-3610,Islanders,NA,NA,NA,NA,NA,https://www.thebluealliance.com/3610
-3630,Stampede,https://breckstampede.org,NA,https://twitter.com/stampede3630,NA,NA,https://www.thebluealliance.com/3630
-3633,Catalyst 3633,https://www.facebook.com/FRC3633,NA,NA,NA,NA,https://www.thebluealliance.com/3633
-3691,RoboRaiders,https://www.northfieldrobotics.com/,https://www.youtube.com/channel/UC417liWB1ym9G4OjYiqytXw?app=desktop,https://twitter.com/Roboraiders3691,https://www.facebook.com/Roboraiders3691/,https://www.instagram.com/roboraiders3691/,https://www.thebluealliance.com/3691
-3723,TEKnights,https://kingslandteknights.weebly.com/,NA,NA,NA,NA,https://www.thebluealliance.com/3723
-3740,Storm Robotics,https://stormrobotic.weebly.com/,https://www.youtube.com/channel/UCdV9OUKaYaZoOhvZNbMr4Ng/featured,https://twitter.com/storm_robotics?lang=en,NA,https://www.instagram.com/9210_stormrobotics/,https://www.thebluealliance.com/3740
-3745,Governors,NA,NA,NA,NA,NA,https://www.thebluealliance.com/3745
-3750,Gator Robotics,https://badgerrobotics3750.wixsite.com/home,NA,https://twitter.com/Robotics_Gator,https://www.facebook.com/BadgerRobotics3750/,https://www.instagram.com/gatorrobotics3750/,https://www.thebluealliance.com/3750
-3751,Tower View Robotics,NA,NA,https://twitter.com/tower_tv,NA,NA,https://www.thebluealliance.com/3751
-3754,TrekNorth First City Robotics,https://team3754.weebly.com/about.html,NA,https://twitter.com/firstcityrobots,NA,NA,https://www.thebluealliance.com/3754
-3755,Dragon Robotics,NA,NA,NA,https://www.facebook.com/Robotics3755/,NA,https://www.thebluealliance.com/3755
-3839,Swolverines,https://www.swolverines.org/,NA,https://twitter.com/wdc_swolverines,https://www.facebook.com/WDCswolverines,https://www.instagram.com/swolverines/,https://www.thebluealliance.com/3839
-3848,Bots in Shining Armour,NA,NA,https://twitter.com/KWRoboticsTeam,NA,NA,https://www.thebluealliance.com/3848
-3871,Trojan Robotics,NA,NA,https://twitter.com/whsfirst,NA,NA,https://www.thebluealliance.com/3871
-3883,Data Bits,https://www.databits3883.com/,https://www.youtube.com/channel/UCgokhIYOmu8USGMhWY2qgkw,https://twitter.com/FRC3883,https://www.facebook.com/FRC3883DataBits,https://www.instagram.com/frc3883/,https://www.thebluealliance.com/3883
-3926,MPArors,https://www.team3926.org/,https://www.youtube.com/user/team3926,https://twitter.com/MPARobotics,https://www.facebook.com/team3926/,NA,https://www.thebluealliance.com/3926
-4009,Denfeld DNA Robotics,http://denfeldrobotics4009.org/,https://www.youtube.com/channel/UCRfC5kOpIyvhPeVY1Yn8l2A,NA,https://www.facebook.com/denfeldrobotics,https://www.instagram.com/dna4009/,https://www.thebluealliance.com/4009
-4166,Robostang,https://morarobotics.weebly.com/,https://www.youtube.com/channel/UC2LnbXgjLcCIAorT7qQ7OgQ,NA,https://www.facebook.com/profile.php?id=100015034716679,https://www.instagram.com/morarobostangs/,https://www.thebluealliance.com/4166
-4174,Mustangs,https://www.blhsd.org/vnews/display.v/SEC/High%20School%7cActivities%3e%3eRobotics,,NA,https://www.facebook.com/blhsroboticsteam/,https://www.instagram.com/blhsrobo/,https://www.thebluealliance.com/4174
-4181,Quack Attack,NA,NA,NA,https://www.facebook.com/quackattack4181/posts/?ref=page_internal,NA,https://www.thebluealliance.com/4181
-4182,Viking Robotics,NA,NA,https://twitter.com/mhs_team4182?lang=en,NA,NA,https://www.thebluealliance.com/4182
-4198,RoboCats,https://robocatsteam4198.wixsite.com/cats,NA,NA,https://www.facebook.com/pg/RoboCats4198/posts/?ref=page_internal,https://www.instagram.com/waconiarobotics/,https://www.thebluealliance.com/4198
-4207,PyroBotics,http://robotics.hfchs.org/robotics.php,NA,https://twitter.com/HFCHSRobotics,NA,NA,https://www.thebluealliance.com/4207
-4215,Tritons,https://trinitytritonsrobotics.com/,NA,https://twitter.com/Team4215,NA,https://www.instagram.com/tritons4215/,https://www.thebluealliance.com/4215
-4217,Scitobors,https://nkrobotics.webs.com/,NA,https://twitter.com/scitobor4217,NA,NA,https://www.thebluealliance.com/4217
-4225,RoboCats,NA,NA,NA,NA,NA,https://www.thebluealliance.com/4225
-4226,Huskies,http://team4226.github.io/,NA,https://twitter.com/team4226?lang=en,NA,NA,https://www.thebluealliance.com/4226
-4229,Magnetech,https://sites.google.com/a/stpaul.k12.mn.us/team-4229-magnetech/home?authuser=0,,https://twitter.com/4229magnetech,https://www.facebook.com/4229Magnetech/,NA,https://www.thebluealliance.com/4229
-4230,TopperBots,http://www.topperbots4230.com/,https://www.youtube.com/channel/UCMRSdYxoKJUKZ_m3uAl2IwQ,https://twitter.com/TopperBots,https://www.facebook.com/MarshallFRC,https://www.instagram.com/topperbots/,https://www.thebluealliance.com/4230
-4238,Resistance Robotics,NA,NA,NA,NA,NA,https://www.thebluealliance.com/4238
-4239,WARPSPEED,https://warpspeed4239.wordpress.com/,https://www.youtube.com/channel/UCFtRA4nGDbXEPAvbNLMfTcA,https://twitter.com/WARPSPEED4239,NA,https://www.instagram.com/warpspeed_4239/,https://www.thebluealliance.com/4239
-4260,BEAR Bucs,NA,NA,NA,NA,NA,https://www.thebluealliance.com/4260
-4277,Thingamajiggers,https://team4277.webs.com/,NA,https://twitter.com/frc4277,https://www.facebook.com/Thingamajiggers/,https://www.instagram.com/chs4277/,https://www.thebluealliance.com/4277
-4360,Spudnik,NA,NA,https://twitter.com/spudnikrobotics,https://www.facebook.com/MoorheadRobotics4360/,https://www.instagram.com/spudnikrobotics4360/,https://www.thebluealliance.com/4360
-4480,UC-Botics,NA,https://www.youtube.com/user/UCBotics,https://twitter.com/ucbotics,https://www.facebook.com/UCBotics/,NA,https://www.thebluealliance.com/4480
-4506,PioNerds,NA,NA,https://twitter.com/hmrobotics4506,https://www.facebook.com/Pionerds4506/,https://www.instagram.com/pionerds/,https://www.thebluealliance.com/4506
-4511,Power Amplified,NA,https://www.youtube.com/channel/UCI1OA9FaOTRwKrwsocXux2Q,NA,NA,NA,https://www.thebluealliance.com/4511
-4536,MinuteBots,https://www.minutebots.org/,https://www.youtube.com/channel/UCFU6XLM7Q-EL0o9TM-n0wSA,https://twitter.com/minutebots,https://www.facebook.com/MinuteBots?fref=ts,NA,https://www.thebluealliance.com/4536
-4539,KAOTIC Robotics,https://www.kaoticrobotics.org/,https://www.youtube.com/channel/UCbdzPJaloT7zXST7fg8dUDA,https://twitter.com/KaoticRobotics,https://www.facebook.com/KAOTIC-Robotics-4539-400084090145600/,https://www.instagram.com/kaoticrobotics/,https://www.thebluealliance.com/4539
-4549,Iron Bulls,https://www.ssprobotics.com/,NA,https://twitter.com/ironbulls4549?lang=en,https://www.facebook.com/SSProbotics/,NA,https://www.thebluealliance.com/4549
-4607,C.I.S.,https://sites.google.com/frc4607cis.com/cis4607,https://www.youtube.com/channel/UCuZurGNa2j5dLLE3HOlZM4A,https://twitter.com/cis4607?lang=en,https://www.facebook.com/BeckerRobotics4607/,https://www.instagram.com/cis_4607robotics/?hl=en,https://www.thebluealliance.com/4607
-4623,Flyer Robotics,NA,NA,https://twitter.com/flyerrobotics,https://www.facebook.com/LittleFallsRobotics/,NA,https://www.thebluealliance.com/4623
-4624,Rebel Alliance,https://owatonna4624.wixsite.com/4624,NA,https://twitter.com/owatonna4624,https://www.facebook.com/First-Robotics-Owatonna-212297038900626/?fref=ts,https://www.instagram.com/owatonna4624/,https://www.thebluealliance.com/4624
-4632,Monty-Pythons,https://montipythons.wixsite.com/website,NA,https://twitter.com/montipythons?lang=en,NA,NA,https://www.thebluealliance.com/4632
-4648,Techno-Tech,http://technotechrobotics.com/technotech/,NA,https://twitter.com/technotech4648,NA,NA,https://www.thebluealliance.com/4648
-4656,Rock Solid Robotics,http://twoharborsrobotics.com/,NA,NA,https://www.facebook.com/RockSolid4656/,https://www.instagram.com/rocksolid4656/,https://www.thebluealliance.com/4656
-4663,Cyber Tigers,NA,NA,https://twitter.com/cybertigers4663?lang=en,NA,https://www.instagram.com/cybertigers4663/,https://www.thebluealliance.com/4663
-4664,Butler Bots,NA,NA,https://twitter.com/frc4664,NA,NA,https://www.thebluealliance.com/4664
-4665,Predators,NA,NA,https://twitter.com/gslpredators,https://www.facebook.com/GSL4665/,NA,https://www.thebluealliance.com/4665
-4674,RoboJacks,https://www.robojacks4674.org/,https://www.youtube.com/channel/UCx7dMM9pkVaiNabKnmUBGgg,,https://www.facebook.com/team4674,https://www.instagram.com/robo.jacks/,https://www.thebluealliance.com/4674
-4693,Axiomatic Aftermath,https://sites.google.com/rockford.k12.mn.us/waltersl/robotics,NA,NA,NA,NA,https://www.thebluealliance.com/4693
-4703,Menahga Gigabot$,NA,NA,NA,NA,NA,https://www.thebluealliance.com/4703
-4728,Rocori Rench Reckers,https://frc4728.wixsite.com/first,NA,https://twitter.com/robotics4728,https://www.facebook.com/RocoriRobotics/?ref=bookmarks,NA,https://www.thebluealliance.com/4728
-4741,WingNuts,NA,NA,https://twitter.com/frc4741rvhs?lang=en,https://www.facebook.com/pages/category/Youth-Organization/4741-Wingnuts-2435090523197275/,NA,https://www.thebluealliance.com/4741
-4778,Stormbots,https://sites.google.com/view/chanrobotics,https://www.youtube.com/channel/UCBmJmrtKRYjOS4TM1LlzEUw,https://twitter.com/chanrobotics,NA,https://www.instagram.com/chanrobotics/,https://www.thebluealliance.com/4778
-4845,Lion's Pride,NA,NA,https://twitter.com/frc4845,https://www.facebook.com/LakeviewRobotics/,https://www.instagram.com/frc4845/,https://www.thebluealliance.com/4845
-4859,The CyBears,https://sites.google.com/byron.k12.mn.us/byronrobotics,NA,https://twitter.com/byronrobotics?lang=en,https://www.facebook.com/ByronRobotics/,https://www.instagram.com/byron_cybears4859/?hl=en,https://www.thebluealliance.com/4859
-5143,GRG Raw Steel,NA,NA,NA,NA,NA,https://www.thebluealliance.com/5143
-5172,Gators,https://5172gators.org/,https://www.youtube.com/user/gmrrobotics,https://twitter.com/gmrrobotics,https://facebook.com/5172gators,https://www.instagram.com/gatorrobotics_5172/,https://www.thebluealliance.com/5172
-5232,Talons,NA,https://www.youtube.com/channel/UCUiEHgqclFZZ6td4ebNIVbw,NA,https://www.facebook.com/HermantownTalons5232/,NA,https://www.thebluealliance.com/5232
-5253,Bigfork Backwoods Bots,NA,NA,NA,NA,NA,https://www.thebluealliance.com/5253
-5271,Open Circuits,https://opencircuits.weebly.com/,NA,https://twitter.com/owlopencircuits?lang=en,NA,NA,https://www.thebluealliance.com/5271
-5275,T.I.M.E. Bots,https://timebots5275.com/,https://www.youtube.com/channel/UCb_E6_67T-BqZU3DlorhrCA,https://twitter.com/timebots5275,https://www.facebook.com/NewPragueTIMEBots5275FRC/,NA,https://www.thebluealliance.com/5275
-5278,Los Clasicos,NA,NA,NA,https://www.facebook.com/los.clasicos.5278,https://www.instagram.com/los.clasicos5278/,https://www.thebluealliance.com/5278
-5290,Mechanical Howl,NA,NA,https://twitter.com/team5290?lang=en,https://www.facebook.com/Team5290/,NA,https://www.thebluealliance.com/5290
-5299,Winger Tech,https://wingertech5299.wordpress.com/,NA,NA,https://www.facebook.com/pages/category/Community/Winger-Tech-5299-559642941071055/,NA,https://www.thebluealliance.com/5299
-5339,Hurricanes,NA,NA,NA,https://www.facebook.com/FRCteam5339/,NA,https://www.thebluealliance.com/5339
-5340,FAIRmingers,http://www.fairmingos.com/,NA,https://twitter.com/fairmingos,NA,NA,https://www.thebluealliance.com/5340
-5348,Charger Robotics,NA,https://www.youtube.com/channel/UCedHYi9jrupQBTPITDVxzog,NA,NA,https://www.instagram.com/frc5348/?hl=en,https://www.thebluealliance.com/5348
-5434,Falcon Robotics,NA,https://www.youtube.com/channel/UCM7EwJgWRUiafbFKZm0TQGQ,https://twitter.com/falcon_robotics,https://www.facebook.com/Falcon.Robotics/,https://www.instagram.com/faribault.falcon.robotics/?hl=en,https://www.thebluealliance.com/5434
-5464,Bluejacket Robotics,NA,NA,NA,https://www.facebook.com/BluejacketRobotics/,https://www.instagram.com/bluejacketsteam5464/,https://www.thebluealliance.com/5464
-5541,Shakopee Robotics,NA,https://www.youtube.com/channel/UCNu52ijqs5JepFZdRavFj2g/videos?view=0&sort=da&flow=grid,https://twitter.com/shakorobotics?lang=en,https://www.facebook.com/Shakopee-Robotics-831451413567234/,https://www.instagram.com/saber_robotics/,https://www.thebluealliance.com/5541
-5542,RoboHerd,https://www.roboherd5542.com/,NA,NA,https://www.facebook.com/RoboHerd5542/,https://www.instagram.com/buffalo_robotics/?hl=en,https://www.thebluealliance.com/5542
-5626,Nu-matic Ninjas,https://numaticninjas.wixsite.com/centralrobotics5626,NA,https://twitter.com/ninjas5626?lang=en,https://www.facebook.com/ninjas5626/,https://www.instagram.com/ninjas5626/?hl=af,https://www.thebluealliance.com/5626
-5637,Titanium Polars,NA,NA,NA,NA,NA,https://www.thebluealliance.com/5637
-5638,LQPV Robotics,NA,NA,https://twitter.com/frc5638,NA,https://www.instagram.com/frc5638/?hl=en,https://www.thebluealliance.com/5638
-5653,Iron Mosquitos,https://ironmos5653.wixsite.com/web-studio-blog,NA,https://twitter.com/frc5653?lang=en,https://www.facebook.com/Iron-Mosquitoes-FRC-5653-109096880611622/?ref=page_internal,NA,https://www.thebluealliance.com/5653
-5658,STORMBOTICS,NA,NA,NA,NA,NA,https://www.thebluealliance.com/5658
-5690,SubZero Robotics,https://subzerorobotics.wordpress.com/,NA,https://twitter.com/subzerorobotics,https://www.facebook.com/SubZeroRobotics5690/,NA,https://www.thebluealliance.com/5690
-5720,Jagobotics,NA,NA,https://twitter.com/jagobotics5720,NA,NA,https://www.thebluealliance.com/5720
-5913,Patriotics,https://patriotics186.weebly.com/,NA,NA,https://www.facebook.com/patriotics186,NA,https://www.thebluealliance.com/5913
-5914,Robotic Warriors,https://www.7rrc.org/caledonia-1,NA,https://twitter.com/frc5914,https://www.facebook.com/CaledoniaRobotics/,NA,https://www.thebluealliance.com/5914
-5929,The Marauders,NA,NA,NA,https://www.facebook.com/pages/category/Just-For-Fun/The-Marauders-LPA-Team-5929-339821589760175/,NA,https://www.thebluealliance.com/5929
-5991,Chargers,NA,NA,NA,NA,NA,https://www.thebluealliance.com/5991
-5998,The Chillbots,NA,NA,NA,https://www.facebook.com/thechillbotsfrcteam5998,NA,https://www.thebluealliance.com/5998
-5999,Byte Force,NA,NA,https://twitter.com/Byte_Force5999,https://www.facebook.com/byte.force.5,https://www.instagram.com/milaca_byte_force/,https://www.thebluealliance.com/5999
-6022,Wrench Warmers,https://www.wrenchwarmers6022.com/,NA,https://twitter.com/frc6022?lang=en,https://www.facebook.com/wrenchwarmers/,https://www.instagram.com/p/Buzc9_QlJl4/,https://www.thebluealliance.com/6022
-6044,Circuit Breakers,NA,NA,https://mobile.twitter.com/frc6044,https://www.facebook.com/frc6044/,NA,https://www.thebluealliance.com/6044
-6045,Sabre Robotics,https://www.frc6045.org/,NA,https://twitter.com/frc6045,https://www.facebook.com/SabreRobotics/,NA,https://www.thebluealliance.com/6045
-6047,Proctor Frostbyte,https://frostbyte.club/,NA,https://twitter.com/phsfrostbyte?lang=en,NA,NA,https://www.thebluealliance.com/6047
-6132,Iron Rangers,https://rangerrobotics.weebly.com/,https://www.youtube.com/channel/UCsAq_VMHYMtDjIzkwz01sZg,https://twitter.com/Ranger_Robotics,NA,NA,https://www.thebluealliance.com/6132
-6146,Blackjacks,NA,NA,https://twitter.com/DBHSRobotics,https://www.facebook.com/dawsonboydrobotics/,https://www.instagram.com/dbhsrobotics/,https://www.thebluealliance.com/6146
-6147,Tonkabots,NA,NA,https://twitter.com/tonka_bots?lang=en,NA,NA,https://www.thebluealliance.com/6147
-6160,Bombatrons,https://bombatrons.weebly.com/,NA,https://twitter.com/bombatrons,https://www.facebook.com/bombatrons/,https://www.instagram.com/bombatrons/,https://www.thebluealliance.com/6160
-6475,EVW Mystery Machine,https://sites.google.com/evw.k12.mn.us/6175-mm-robotics,NA,https://twitter.com/6175machine,NA,NA,https://www.thebluealliance.com/6475
-6217,Bomb-Botz,NA,NA,https://twitter.com/6217cfhs,https://www.facebook.com/cfhs6217,https://www.instagram.com/cfhs_6217/,https://www.thebluealliance.com/6217
-6453,Bog Bots,https://www.bogbots6453.org/,NA,NA,https://www.facebook.com/bogbots6453/,https://www.instagram.com/kelliherbogbots_6453/,https://www.thebluealliance.com/6453
-6628,KMS Botkickers,NA,NA,NA,NA,NA,https://www.thebluealliance.com/6628
-6707,RCW Jaguar Robosapiens,NA,NA,NA,NA,NA,https://www.thebluealliance.com/6707
-6709,Spudinc,https://biglakerobotics.wixsite.com/mysite,NA,https://twitter.com/spudinc6709,https://www.facebook.com/spudinc6709/,https://www.instagram.com/biglakerobotics/,https://www.thebluealliance.com/6709
-6749,tERAbytes,NA,NA,https://twitter.com/team6749,NA,NA,https://www.thebluealliance.com/6749
-6758,Otternauts,NA,NA,https://twitter.com/kmrobotics?lang=en,https://www.facebook.com/kmrobotics2017,NA,https://www.thebluealliance.com/6758
-6912,InterGalactic Transformers,NA,NA,NA,NA,NA,https://www.thebluealliance.com/6912
-7019,TechNoLogic,NA,NA,NA,NA,NA,https://www.thebluealliance.com/7019
-7028,Binary Battalion,http://7028robotics.com/,https://www.youtube.com/channel/UCTrd72vnpDdWQ83zk3-plHw,https://twitter.com/stma_robotics?lang=en,https://www.facebook.com/STMARoboticsClub/,NA,https://www.thebluealliance.com/7028
-7038,Pizza Pi's,NA,NA,NA,NA,NA,https://www.thebluealliance.com/7038
-7041,Doomsday Dogs,NA,NA,https://twitter.com/doomsdaydogs?lang=en,https://www.facebook.com/doomsdaydogs7041/?ref=page_internal,https://www.instagram.com/carlton.robotics/?hl=en,https://www.thebluealliance.com/7041
-7068,Mechanical Masterminds,https://www.stfrancisrobotics.org/,NA,NA,https://www.facebook.com/SFHS7068Robotics/,https://www.instagram.com/mechanical.masterminds/,https://www.thebluealliance.com/7068
-7180,Wellstone Lions,NA,NA,NA,NA,NA,https://www.thebluealliance.com/7180
-7235,Red Lake Ogishidaag,NA,NA,NA,https://www.facebook.com/RLHS-Team-7235-336773733475948/,NA,https://www.thebluealliance.com/7235
-7257,Sauk Centre Robotics,NA,NA,https://twitter.com/team7257,NA,NA,https://www.thebluealliance.com/7257
-7258,Hiawatha Collegiate,NA,NA,NA,NA,NA,https://www.thebluealliance.com/7258
-7273,ZooM Robotics,https://zmrobotics.wixsite.com/7273,NA,https://twitter.com/zmrobotics,https://www.facebook.com/ZooMRobotics7273/?__tn__=%2Cd%2CP-R&eid=ARAsrB45IOa3f6Ds43I4ffnHGIiucJttIecY_SfcXm1Hzf7RrXq2f6ey1e5ephtteWnoSGlqCFLmpbeE,https://www.instagram.com/zmrobotics/,https://www.thebluealliance.com/7273
-7311,Boring Robots,https://boring-robotics.neocities.org/,NA,NA,NA,NA,https://www.thebluealliance.com/7311
-7432,NOS,NA,NA,https://twitter.com/frcnos,NA,https://www.instagram.com/frc7432/?hl=en,https://www.thebluealliance.com/7432
-7530,Brotherhood of Steel,https://wmrobotics7530.wixsite.com/7530,NA,https://twitter.com/RoboticsWm,https://www.facebook.com/watertownmayerschooldistrict/,https://www.instagram.com/wm.robotics/,https://www.thebluealliance.com/7530
-7541,Maple River Robotics,NA,NA,NA,https://www.facebook.com/mapleriverrobotics,NA,https://www.thebluealliance.com/7541
-7677,Brodacious Bulldogs,NA,NA,NA,NA,NA,https://www.thebluealliance.com/7677
-7797,Cloquet's Ripsaw Robotics,https://ripsawrobotics.weebly.com/,NA,https://twitter.com/ripsawr,https://www.facebook.com/groups/486187188458178/?ref=group_header,https://www.instagram.com/ripsawrobotics/,https://www.thebluealliance.com/7797
-7849,Chi You's G3AR T3K3,NA,NA,https://twitter.com/7849ers,NA,NA,https://www.thebluealliance.com/7849
-7850,C.A.R.D.S,NA,NA,NA,https://www.facebook.com/Robotics.CRHS/,NA,https://www.thebluealliance.com/7850
-7858,Warriors,http://64.8.149.185:82/index.html,NA,NA,https://www.facebook.com/warriorrobotics7858,https://www.instagram.com/warrior_robotics7858/,https://www.thebluealliance.com/7858
-7864,North Woods Robotics,NA,NA,NA,NA,NA,https://www.thebluealliance.com/7864
-7875,MNIC Robotics,NA,NA,https://twitter.com/7875mnic,NA,NA,https://www.thebluealliance.com/7875
-7893,Maple Lake High School,NA,NA,NA,NA,NA,https://www.thebluealliance.com/7893
-8234,Panthinators,NA,NA,NA,https://www.facebook.com/slprobotics/,NA,https://www.thebluealliance.com/8234
-8298,Mighty Morphing Banana Slugs,http://frc8298.com/,NA,NA,NA,https://www.instagram.com/luvernerobotics/,https://www.thebluealliance.com/8298
-8347,Broken Eagles,NA,NA,NA,NA,NA,https://www.thebluealliance.com/8347
-8355,Melanin Minds,NA,NA,NA,NA,https://www.instagram.com/mmelaninminds/,https://www.thebluealliance.com/8355
-8372,HCN Storm,NA,NA,NA,NA,NA,https://www.thebluealliance.com/8372
-8409,Kato Coyote's,NA,NA,NA,NA,NA,https://www.thebluealliance.com/8409
-8412,Battle Lake Schools,NA,NA,NA,NA,NA,https://www.thebluealliance.com/8412
-8416,Wolfbotics,NA,NA,NA,NA,NA,https://www.thebluealliance.com/8416
-8422,Pillager High School,NA,NA,NA,NA,NA,https://www.thebluealliance.com/8422
-8516,Wired Up,NA,NA,NA,NA,NA,https://www.thebluealliance.com/8516
-8887,West Central Area Knights 22,NA,NA,NA,NA,NA,https://www.thebluealliance.com/8887
-8878,ArrowBot,NA,NA,NA,NA,NA,https://www.thebluealliance.com/8878
-8787,Mavericks,NA,NA,NA,NA,NA,https://www.thebluealliance.com/8787
-8836,Wayne Enterprises Inc.,NA,NA,NA,NA,NA,https://www.thebluealliance.com/8836
+1816,"""The Green Machine""",https://edinarobotics.com/,https://www.youtube.com/user/1816EdinaRobotics,https://twitter.com/firstteam1816,https://www.facebook.com/Team-1816-The-Green-Machine-113912638660613/,NA,https://www.thebluealliance.com/team/1816
+2052,KnightKrawler,https://www.team2052.com/,https://www.youtube.com/user/KK2052,https://twitter.com/team2052,https://www.facebook.com/team2052,https://www.instagram.com/team2052/,https://www.thebluealliance.com/team/2052
+2129,Ultraviolet,https://www.swrobotics.com/,NA,https://twitter.com/swrobotics,https://www.facebook.com/SW-Robotics-363257017757341/,https://www.instagram.com/swrobotics/,https://www.thebluealliance.com/team/2129
+2169,KING TeC,https://kingtec2169.com/,https://www.youtube.com/frc2169,https://twitter.com/frc2169,https://www.facebook.com/FRC2169/,https://www.instagram.com/kingtec2169/,https://www.thebluealliance.com/team/2169
+2175,The Fighting Calculators,https://fightingcalculators.org/,https://www.youtube.com/user/frc2175,https://twitter.com/frc2175,https://www.facebook.com/frc2175/,https://www.instagram.com/fightingcalculators2175/,https://www.thebluealliance.com/team/2175
+2177,The Robettes,https://www.therobettes.com/,NA,https://twitter.com/therobettes,https://www.facebook.com/therobettes/,https://www.instagram.com/frc2177therobettes/,https://www.thebluealliance.com/team/2177
+2181,G.E.A.R.S,https://sites.google.com/view/blainefrcteam2181gears,NA,https://twitter.com/frcteam2181,NA,https://www.instagram.com/frcteam2181/,https://www.thebluealliance.com/team/2181
+2207,Bright Bears,http://www.whitebearlakerobotics.com/,NA,https://twitter.com/Team2207,NA,NA,https://www.thebluealliance.com/team/2207
+2220,Blue Twilight,http://team2220.org/,https://www.youtube.com/user/Team2220BlueTwilight,https://twitter.com/2220robotics,https://www.facebook.com/Eagan-High-School-First-Robotics-Team-2220-182480911786242/,https://www.instagram.com/2220bluetwilight/,https://www.thebluealliance.com/team/2220
+2225,R.U.S.T,http://www.first2225.com/,NA,https://twitter.com/Team2225,https://www.facebook.com/RUST2225/,https://www.instagram.com/rust.2225/,https://www.thebluealliance.com/team/2225
+2227,Tigers,https://sites.google.com/site/fridleyrobotics/home,NA,https://twitter.com/team_2227?lang=en,https://www.facebook.com/TigerRobotics2227/,https://www.instagram.com/fridleytigerrobotics/,https://www.thebluealliance.com/team/2227
+2232,Deus ex Machina,NA,NA,NA,https://www.facebook.com/FRC2232/,https://www.instagram.com/anoka_frc_2232/?hl=en,https://www.thebluealliance.com/team/2232
+2239,Technocrats,https://sites.google.com/view/2239/home,NA,https://twitter.com/Team2239,https://www.facebook.com/2239Technocrats/,https://www.instagram.com/frc2239/,https://www.thebluealliance.com/team/2239
+2264,Trojan Robotics,https://wayzatarobotics2264.com/,NA,NA,https://www.facebook.com/wayzatarobotics,https://www.instagram.com/wayzatarobotics/,https://www.thebluealliance.com/team/2264
+2450,Wind Chill,NA,NA,NA,https://www.facebook.com/pg/CDHRaiderbots/posts/?ref=page_internal,NA,https://www.thebluealliance.com/team/2450
+2470,Team BJORG,https://www.team2470.org/,NA,https://twitter.com/teambjorg,https://www.facebook.com/TeamBJORG/,https://www.instagram.com/teambjorg/,https://www.thebluealliance.com/team/2470
+2472,Centurions,https://sites.google.com/view/team2472robotics/home,https://www.youtube.com/channel/UClgB3Fmbcc9tpoaoolKMHsg,https://twitter.com/team_2472,NA,https://www.instagram.com/2472centurions/,https://www.thebluealliance.com/team/2472
+2479,Pheonix,NA,NA,NA,NA,NA,https://www.thebluealliance.com/team/2479
+2480,Roosevelt Robotics,NA,NA,https://twitter.com/rhsrobotics2480,https://www.facebook.com/RooseveltRobotics/,NA,https://www.thebluealliance.com/team/2480
+2491,NoMythic,http://www.2491nomythic.com/,https://www.youtube.com/user/NoMthic2491,https://twitter.com/2491NoMythic,https://www.facebook.com/2491NoMythic,https://www.instagram.com/2491nomythic/?hl=en,https://www.thebluealliance.com/team/2491
+2498,BearBotics,NA,NA,NA,NA,https://www.instagram.com/blakebearbotics/,https://www.thebluealliance.com/team/2498
+2499,Industrial Revolution,NA,NA,https://twitter.com/hibbingfrc,https://www.facebook.com/Hibbing-FRC-Robotics-Team-2499-172934836106391/,https://www.instagram.com/frcteam2499/?hl=en,https://www.thebluealliance.com/team/2499
+2500,Herobotics,https://herobotics.org/,https://www.youtube.com/user/Herobotics2500,https://twitter.com/FRC2500,https://www.facebook.com/2500Herobotics/,https://www.instagram.com/herobotics2500/,https://www.thebluealliance.com/team/2500
+2501,Bionic Polars,http://www.team2501.com/,https://www.youtube.com/channel/UCBYnxa-AIjwneKbKdl6bzwQ,https://twitter.com/FRC2501,https://www.facebook.com/team2501,NA,https://www.thebluealliance.com/team/2501
+2502,Talon Robotics,http://team2502.com/,NA,https://twitter.com/frc2502?lang=en,https://www.facebook.com/team2502/,NA,https://www.thebluealliance.com/team/2502
+2503,Warrior Robotics,https://sites.google.com/isd181.org/team2503/home,https://www.youtube.com/channel/UC83ddnAHC1JnSCkWlbYsJvg/featured,NA,NA,https://www.instagram.com/team2503wr/?hl=en,https://www.thebluealliance.com/team/2503
+2508,Armada,https://frc2508.org/,https://www.youtube.com/user/ArmadaRobotics,https://twitter.com/frc2508,https://www.facebook.com/FRC2508/,https://www.instagram.com/frc2508/,https://www.thebluealliance.com/team/2508
+2509,Tigerbots,https://sites.google.com/a/isd423.org/frc2509/,NA,https://twitter.com/tigerbots2509,https://www.facebook.com/tigerbots2509,NA,https://www.thebluealliance.com/team/2509
+2511,Cougars,https://lshsrobotics.wixsite.com/cougars-frc,NA,https://twitter.com/frcteam2511,NA,NA,https://www.thebluealliance.com/team/2511
+2512,Duluth East Daredevils,https://daredevils2512.org/,https://www.youtube.com/channel/UCuZ2AjvVFjU7kajfJTL-5NQ,https://twitter.com/FRC2512,https://www.facebook.com/Daredevils2512/,https://www.instagram.com/frc2512/,https://www.thebluealliance.com/team/2512
+2513,TERTOLA,NA,NA,NA,NA,NA,https://www.thebluealliance.com/team/2513
+2515,Marshall Robotics and Engineering,NA,NA,https://twitter.com/frc2515,https://www.facebook.com/frc2515,https://www.instagram.com/frc2515/,https://www.thebluealliance.com/team/2515
+2518,Spartan Robotics,http://first2518.weebly.com/,https://www.youtube.com/user/FIRSTTeam2518,https://twitter.com/firstteam2518,NA,NA,https://www.thebluealliance.com/team/2518
+2525,The pHalcons,NA,NA,NA,NA,NA,https://www.thebluealliance.com/team/2525
+2526,Crimson Robotics,http://www.crimsonrobotics.com/,https://www.youtube.com/channel/UClWmTsYwaLQvqMJO2RCj93g,https://twitter.com/Crimson2526,https://www.facebook.com/Crimson-Robotics-734231373272992/,https://www.instagram.com/crimsonrobotics/,https://www.thebluealliance.com/team/2526
+2529,The WHO,NA,NA,NA,NA,NA,https://www.thebluealliance.com/team/2529
+2530,Inconceivable,http://frcteam2530.org/,NA,https://twitter.com/FRCTEAM2530,https://www.facebook.com/FIRSTRobotics2530Inconceivable,https://www.instagram.com/inconceivablemn/,https://www.thebluealliance.com/team/2530
+2531,RoboHawks,https://robohawks2531.weebly.com/,https://www.youtube.com/user/2531Robohawks,https://twitter.com/2531RoboHawks,NA,https://www.instagram.com/2531robohawks/,https://www.thebluealliance.com/team/2531
+2532,FLASH Power,http://flashpower2532.weebly.com/,NA,https://twitter.com/frc2532?lang=en,NA,NA,https://www.thebluealliance.com/team/2532
+2538,The Plaid Pillagers,https://team2538.wordpress.com/,NA,https://twitter.com/plaid_pillagers?lang=en,https://www.facebook.com/inPLAIDorINSANE/,NA,https://www.thebluealliance.com/team/2538
+2545,Quantum Mechanics,NA,https://www.youtube.com/channel/UCF9E_vcIJ8L-Z0RxSf41hiQ,https://twitter.com/chhs_robotics,https://www.facebook.com/2545-Robotics-CHHS-156135351113173/,NA,https://www.thebluealliance.com/team/2545
+2549,Millerbots,https://washburnmillerbots.com/,https://www.youtube.com/channel/UCnqfl9RVsy3yAowlyimnb6g,https://twitter.com/whsmillerbots,https://www.facebook.com/millerbots/,https://www.instagram.com/whsmillerbots/?utm_source=ig_profile_share&igshid=1o35qzot8ptnd,https://www.thebluealliance.com/team/2549
+2574,RoboHuskie,NA,https://www.youtube.com/user/StAnthonyRoboHuskie,https://twitter.com/robohuskie2574,https://www.facebook.com/pg/Robohuskie/about/?ref=page_internal,https://www.instagram.com/robohuskie2574/,https://www.thebluealliance.com/team/2574
+2606,Irish Robotics,https://sites.google.com/a/apps.district196.org/irish-robotics/home,NA,https://twitter.com/irish_2606,https://www.facebook.com/IrishRobotics/,https://www.instagram.com/irishrobotics/,https://www.thebluealliance.com/team/2606
+2654,Polar Rams,http://polarrams.com/,NA,https://twitter.com/2654roborams,https://m.facebook.com/PolarRams,https://www.instagram.com/polarramsrm/,https://www.thebluealliance.com/team/2654
+2667,Knights of the Valley,http://www.team2667.org/,NA,https://twitter.com/FRC2667,https://www.facebook.com/FIRSTTEAM2667/,https://www.instagram.com/frcteam2667/,https://www.thebluealliance.com/team/2667
+2823,The Automatons,http://www.hprobotics.org/,https://www.youtube.com/user/highland2823,https://twitter.com/hprobotics,https://www.facebook.com/HPRobotics,https://www.instagram.com/hprobotics2823/,https://www.thebluealliance.com/team/2823
+2825,Roc Robotics,NA,NA,NA,https://www.facebook.com/Team-2825-Roc-Robotics-1541288902856344/,NA,https://www.thebluealliance.com/team/2825
+2846,FireBears,http://firebears.org/,https://www.youtube.com/c/FirebearsOrg,https://twitter.com/firebears2846,https://www.facebook.com/FireBears2846,https://www.instagram.com/firebears2846/,https://www.thebluealliance.com/team/2846
+2847,The MegaHertz,https://megahertz-team2847.webs.com/,NA,https://twitter.com/2847Megahertz,https://www.facebook.com/Team2847/,https://www.instagram.com/frc_team2847/,https://www.thebluealliance.com/team/2847
+2861,Infinity's End,https://sites.google.com/a/lake-city.k12.mn.us/2861-infinity-s-end/,https://www.youtube.com/channel/UCIZDymD5QqjCaBOpJWCW-EA,https://twitter.com/frc2861?lang=en,NA,NA,https://www.thebluealliance.com/team/2861
+2879,Oriole Robotics,NA,NA,https://twitter.com/frc2879,https://www.facebook.com/FRC2879/,NA,https://www.thebluealliance.com/team/2879
+2883,F.R.E.D,https://www.team2883.com/,https://www.youtube.com/channel/UCm9tddMsUaVkkfdhB9oLolw/featured,https://twitter.com/teamfred2883,https://www.facebook.com/team2883,https://www.instagram.com/teamfred2883/,https://www.thebluealliance.com/team/2883
+2957,Knights,NA,NA,NA,NA,NA,https://www.thebluealliance.com/team/2957
+2977,Sir Lancer Bots,https://lacrescentrobotics.com/,NA,https://twitter.com/sirlancerbots,https://www.facebook.com/sirlancerbots/,https://www.instagram.com/sirlancerbots/,https://www.thebluealliance.com/team/2977
+2987,Rogue Robotics,https://www.team2987.com/,NA,https://twitter.com/rogue_robotics,https://www.facebook.com/roguerobotics2987/,https://www.instagram.com/roguerobotics/,https://www.thebluealliance.com/team/2987
+2989,Star Tech,http://team2989.weebly.com/,https://www.youtube.com/channel/UC6jwARmfNxvDXPb6KrPwKoA,https://twitter.com/frcteam2989,NA,NA,https://www.thebluealliance.com/team/2989
+3007,Robotitans,https://sites.google.com/view/team-3007/home,https://www.youtube.com/channel/UCoPYTR4KwSRjoG-3LHRHtGQ,https://twitter.com/frcteam3007,NA,NA,https://www.thebluealliance.com/team/3007
+3018,Nordic Storm,https://www.nordicstorm.org/,NA,https://twitter.com/nordicstorm3018,https://www.facebook.com/NordicStorm3018/,NA,https://www.thebluealliance.com/team/3018
+3023,STARK Industries,http://team3023.org/,NA,https://twitter.com/FRCTeam3023,https://www.facebook.com/FRCTeam3023/,https://www.instagram.com/team3023/,https://www.thebluealliance.com/team/3023
+3026,Orange Crush Robotics,https://www.orangecrush3026.com/,NA,https://twitter.com/ocr3026?lang=en,https://www.facebook.com/orangecrushrobotics/,https://www.instagram.com/ocr3026/?hl=en,https://www.thebluealliance.com/team/3026
+3038,ICE,https://sites.google.com/site/team3038ice,https://www.youtube.com/user/ICE3038,https://twitter.com/ice3038,https://www.facebook.com/3038ICE/,https://www.instagram.com/3038i.c.e.robotics/,https://www.thebluealliance.com/team/3038
+3042,Cobalt Catalysts,https://team3042.weebly.com/,https://www.youtube.com/user/EastviewCobalt,https://twitter.com/Cobalt3042,https://www.facebook.com/Cobalt3042/,https://www.instagram.com/3042_cobalt_catalysts/,https://www.thebluealliance.com/team/3042
+3054,IceStorm,NA,NA,NA,https://www.facebook.com/CCHSIceStormRobotics3054/,NA,https://www.thebluealliance.com/team/3054
+3055,Furious George,NA,NA,https://twitter.com/3055george,https://www.facebook.com/FuriousGeorgeTeam3055/,https://www.instagram.com/3055furiousgeorge/,https://www.thebluealliance.com/team/3055
+3058,AnnDroids,http://www.anndroids3058.com/,NA,https://twitter.com/Anndroids_3058,https://www.facebook.com/mr.roboto.18,https://www.instagram.com/team_3058/,https://www.thebluealliance.com/team/3058
+3082,Chicken Bot Pie,https://team3082.com/,NA,https://twitter.com/Team3082/,https://www.facebook.com/team3082/,https://www.instagram.com/chickenbotpie/,https://www.thebluealliance.com/team/3082
+3090,Ramkawks,NA,NA,NA,https://www.facebook.com/Team3090/,NA,https://www.thebluealliance.com/team/3090
+3100,Lightning Turtles,https://team3100.com/,https://www.youtube.com/channel/UCasCnsLlqfCEV9WlaFmJqGA,https://twitter.com/frc3100,https://www.facebook.com/FRC3100/,https://www.instagram.com/frc_3100/,https://www.thebluealliance.com/team/3100
+3102,Tech-No-Tigers,https://www.tnt3102.org/,NA,NA,https://www.facebook.com/tnt3102,https://www.instagram.com/tnt3102/,https://www.thebluealliance.com/team/3102
+3122,The Alluminators,NA,NA,https://twitter.com/frc3122,https://www.facebook.com/frc3122,NA,https://www.thebluealliance.com/team/3122
+3130,The ERRORs,NA,https://www.youtube.com/user/error3130,https://twitter.com/errors3130,https://www.facebook.com/error3130,https://www.instagram.com/errors3130/,https://www.thebluealliance.com/team/3130
+3134,The Accelerators,http://clbrobotics.weebly.com/,https://www.youtube.com/channel/UCQUszqXL0Cr8I4wezAbMefA,NA,https://www.facebook.com/acceleratorsandregulators/,NA,https://www.thebluealliance.com/team/3134
+3184,Blaze Robotics,https://www.blazerobotics.org/,https://www.youtube.com/user/team3184,https://twitter.com/Team3184?lang=en,https://www.facebook.com/BlazeRobotics/,https://www.instagram.com/blazerobotics/,https://www.thebluealliance.com/team/3184
+3202,KnightBots,https://sites.google.com/site/hardingknightbots/home,NA,NA,https://www.facebook.com/knightbots/,NA,https://www.thebluealliance.com/team/3202
+3206,Royal T-Wrecks,https://www.whsactivities.org/robotics,https://www.youtube.com/channel/UCcW_rWXi3W02IrdMRdR7EFQ,https://twitter.com/RTWrecks,NA,https://www.instagram.com/frc3206/,https://www.thebluealliance.com/team/3206
+3212,YME Stingbots,NA,NA,NA,https://www.facebook.com/YME-Stingbots-3212-141313229686050/,NA,https://www.thebluealliance.com/team/3212
+3244,Granite City Gear Heads,http://www.granitecitygearheads.com/,https://www.youtube.com/user/GearHeads3244,https://twitter.com/gcgearheads,https://www.facebook.com/granitecitygearheads3244,https://www.instagram.com/gcgearheads/,https://www.thebluealliance.com/team/3244
+3267,Mariner Robotics,NA,NA,NA,https://www.facebook.com/WKHS-Mariner-Robotics-870746146378688/,NA,https://www.thebluealliance.com/team/3267
+3275,The Regulators,http://clbregulators.weebly.com/,NA,NA,NA,NA,https://www.thebluealliance.com/team/3275
+3276,ToolCats,https://www.nls.k12.mn.us/Page/2153#calendar4399/20200301/month,NA,NA,NA,NA,https://www.thebluealliance.com/team/3276
+3277,ProDigi,NA,NA,https://twitter.com/prodigi3277,https://www.facebook.com/Prodigi3277/,https://www.instagram.com/prodigi3277/,https://www.thebluealliance.com/team/3277
+3278,QWERTY Robotics,http://qwertyrobotics.org,https://www.youtube.com/channel/UC-GtJBg6khOMis0vaetbAbQ,NA,https://www.facebook.com/qwertyrobotics/,NA,https://www.thebluealliance.com/team/3278
+3291,AU Pirates,https://sites.google.com/apps.district279.org/au-pirates-pc/about/about-us,,https://twitter.com/parkcenterrobot?lang=en,https://www.facebook.com/3291AuPirates/,https://www.instagram.com/aupirates_3291/,https://www.thebluealliance.com/team/3291
+3293,OtterBots,NA,NA,NA,NA,NA,https://www.thebluealliance.com/team/3293
+3294,Backwoods Engineers,NA,NA,NA,https://www.facebook.com/backwoodsengineers3294/,,https://www.thebluealliance.com/team/3294
+3297,Full Metal Jackets,https://perhamyellowjackets.com/teams/2956273/robotics/varsity,NA,NA,NA,NA,https://www.thebluealliance.com/team/3297
+3298,ArrowBots,NA,NA,NA,https://www.facebook.com/PAS.Robotics.3298/,NA,https://www.thebluealliance.com/team/3298
+3299,The Warehouse Crew,NA,https://www.youtube.com/channel/UCAGFQAe-CJWn-_6Xs1rYYJw/videos?disable_polymer=1,NA,NA,NA,https://www.thebluealliance.com/team/3299
+3300,Midwest WARRIORS,https://team3300.wixsite.com/midwestwarriors,NA,NA,NA,NA,https://www.thebluealliance.com/team/3300
+3313,Mechatronics,http://www.team3313.com,https://www.youtube.com/user/Team3313Mechatronics,https://twitter.com/team3313,https://www.facebook.com/Team3313/,https://www.instagram.com/team3313/,https://www.thebluealliance.com/team/3313
+3407,Wild Cards,NA,NA,NA,NA,NA,https://www.thebluealliance.com/team/3407
+3454,Z Bots,NA,NA,NA,NA,NA,https://www.thebluealliance.com/team/3454
+3610,Islanders,NA,NA,NA,NA,NA,https://www.thebluealliance.com/team/3610
+3630,Stampede,https://breckstampede.org,NA,https://twitter.com/stampede3630,NA,NA,https://www.thebluealliance.com/team/3630
+3633,Catalyst 3633,https://www.facebook.com/FRC3633,NA,NA,NA,NA,https://www.thebluealliance.com/team/3633
+3691,RoboRaiders,https://www.northfieldrobotics.com/,https://www.youtube.com/channel/UC417liWB1ym9G4OjYiqytXw?app=desktop,https://twitter.com/Roboraiders3691,https://www.facebook.com/Roboraiders3691/,https://www.instagram.com/roboraiders3691/,https://www.thebluealliance.com/team/3691
+3723,TEKnights,https://kingslandteknights.weebly.com/,NA,NA,NA,NA,https://www.thebluealliance.com/team/3723
+3740,Storm Robotics,https://stormrobotic.weebly.com/,https://www.youtube.com/channel/UCdV9OUKaYaZoOhvZNbMr4Ng/featured,https://twitter.com/storm_robotics?lang=en,NA,https://www.instagram.com/9210_stormrobotics/,https://www.thebluealliance.com/team/3740
+3745,Governors,NA,NA,NA,NA,NA,https://www.thebluealliance.com/team/3745
+3750,Gator Robotics,https://badgerrobotics3750.wixsite.com/home,NA,https://twitter.com/Robotics_Gator,https://www.facebook.com/BadgerRobotics3750/,https://www.instagram.com/gatorrobotics3750/,https://www.thebluealliance.com/team/3750
+3751,Tower View Robotics,NA,NA,https://twitter.com/tower_tv,NA,NA,https://www.thebluealliance.com/team/3751
+3754,TrekNorth First City Robotics,https://team3754.weebly.com/about.html,NA,https://twitter.com/firstcityrobots,NA,NA,https://www.thebluealliance.com/team/3754
+3755,Dragon Robotics,NA,NA,NA,https://www.facebook.com/Robotics3755/,NA,https://www.thebluealliance.com/team/3755
+3839,Swolverines,https://www.swolverines.org/,NA,https://twitter.com/wdc_swolverines,https://www.facebook.com/WDCswolverines,https://www.instagram.com/swolverines/,https://www.thebluealliance.com/team/3839
+3848,Bots in Shining Armour,NA,NA,https://twitter.com/KWRoboticsTeam,NA,NA,https://www.thebluealliance.com/team/3848
+3871,Trojan Robotics,NA,NA,https://twitter.com/whsfirst,NA,NA,https://www.thebluealliance.com/team/3871
+3883,Data Bits,https://www.databits3883.com/,https://www.youtube.com/channel/UCgokhIYOmu8USGMhWY2qgkw,https://twitter.com/FRC3883,https://www.facebook.com/FRC3883DataBits,https://www.instagram.com/frc3883/,https://www.thebluealliance.com/team/3883
+3926,MPArors,https://www.team3926.org/,https://www.youtube.com/user/team3926,https://twitter.com/MPARobotics,https://www.facebook.com/team3926/,NA,https://www.thebluealliance.com/team/3926
+4009,Denfeld DNA Robotics,http://denfeldrobotics4009.org/,https://www.youtube.com/channel/UCRfC5kOpIyvhPeVY1Yn8l2A,NA,https://www.facebook.com/denfeldrobotics,https://www.instagram.com/dna4009/,https://www.thebluealliance.com/team/4009
+4166,Robostang,https://morarobotics.weebly.com/,https://www.youtube.com/channel/UC2LnbXgjLcCIAorT7qQ7OgQ,NA,https://www.facebook.com/profile.php?id=100015034716679,https://www.instagram.com/morarobostangs/,https://www.thebluealliance.com/team/4166
+4174,Mustangs,https://www.blhsd.org/vnews/display.v/SEC/High%20School%7cActivities%3e%3eRobotics,,NA,https://www.facebook.com/blhsroboticsteam/,https://www.instagram.com/blhsrobo/,https://www.thebluealliance.com/team/4174
+4181,Quack Attack,NA,NA,NA,https://www.facebook.com/quackattack4181/posts/?ref=page_internal,NA,https://www.thebluealliance.com/team/4181
+4182,Viking Robotics,NA,NA,https://twitter.com/mhs_team4182?lang=en,NA,NA,https://www.thebluealliance.com/team/4182
+4198,RoboCats,https://robocatsteam4198.wixsite.com/cats,NA,NA,https://www.facebook.com/pg/RoboCats4198/posts/?ref=page_internal,https://www.instagram.com/waconiarobotics/,https://www.thebluealliance.com/team/4198
+4207,PyroBotics,http://robotics.hfchs.org/robotics.php,NA,https://twitter.com/HFCHSRobotics,NA,NA,https://www.thebluealliance.com/team/4207
+4215,Tritons,https://trinitytritonsrobotics.com/,NA,https://twitter.com/Team4215,NA,https://www.instagram.com/tritons4215/,https://www.thebluealliance.com/team/4215
+4217,Scitobors,https://nkrobotics.webs.com/,NA,https://twitter.com/scitobor4217,NA,NA,https://www.thebluealliance.com/team/4217
+4225,RoboCats,NA,NA,NA,NA,NA,https://www.thebluealliance.com/team/4225
+4226,Huskies,http://team4226.github.io/,NA,https://twitter.com/team4226?lang=en,NA,NA,https://www.thebluealliance.com/team/4226
+4229,Magnetech,https://sites.google.com/a/stpaul.k12.mn.us/team-4229-magnetech/home?authuser=0,,https://twitter.com/4229magnetech,https://www.facebook.com/4229Magnetech/,NA,https://www.thebluealliance.com/team/4229
+4230,TopperBots,http://www.topperbots4230.com/,https://www.youtube.com/channel/UCMRSdYxoKJUKZ_m3uAl2IwQ,https://twitter.com/TopperBots,https://www.facebook.com/MarshallFRC,https://www.instagram.com/topperbots/,https://www.thebluealliance.com/team/4230
+4238,Resistance Robotics,NA,NA,NA,NA,NA,https://www.thebluealliance.com/team/4238
+4239,WARPSPEED,https://warpspeed4239.wordpress.com/,https://www.youtube.com/channel/UCFtRA4nGDbXEPAvbNLMfTcA,https://twitter.com/WARPSPEED4239,NA,https://www.instagram.com/warpspeed_4239/,https://www.thebluealliance.com/team/4239
+4260,BEAR Bucs,NA,NA,NA,NA,NA,https://www.thebluealliance.com/team/4260
+4277,Thingamajiggers,https://team4277.webs.com/,NA,https://twitter.com/frc4277,https://www.facebook.com/Thingamajiggers/,https://www.instagram.com/chs4277/,https://www.thebluealliance.com/team/4277
+4360,Spudnik,NA,NA,https://twitter.com/spudnikrobotics,https://www.facebook.com/MoorheadRobotics4360/,https://www.instagram.com/spudnikrobotics4360/,https://www.thebluealliance.com/team/4360
+4480,UC-Botics,NA,https://www.youtube.com/user/UCBotics,https://twitter.com/ucbotics,https://www.facebook.com/UCBotics/,NA,https://www.thebluealliance.com/team/4480
+4506,PioNerds,NA,NA,https://twitter.com/hmrobotics4506,https://www.facebook.com/Pionerds4506/,https://www.instagram.com/pionerds/,https://www.thebluealliance.com/team/4506
+4511,Power Amplified,NA,https://www.youtube.com/channel/UCI1OA9FaOTRwKrwsocXux2Q,NA,NA,NA,https://www.thebluealliance.com/team/4511
+4536,MinuteBots,https://www.minutebots.org/,https://www.youtube.com/channel/UCFU6XLM7Q-EL0o9TM-n0wSA,https://twitter.com/minutebots,https://www.facebook.com/MinuteBots?fref=ts,NA,https://www.thebluealliance.com/team/4536
+4539,KAOTIC Robotics,https://www.kaoticrobotics.org/,https://www.youtube.com/channel/UCbdzPJaloT7zXST7fg8dUDA,https://twitter.com/KaoticRobotics,https://www.facebook.com/KAOTIC-Robotics-4539-400084090145600/,https://www.instagram.com/kaoticrobotics/,https://www.thebluealliance.com/team/4539
+4549,Iron Bulls,https://www.ssprobotics.com/,NA,https://twitter.com/ironbulls4549?lang=en,https://www.facebook.com/SSProbotics/,NA,https://www.thebluealliance.com/team/4549
+4607,C.I.S.,https://sites.google.com/frc4607cis.com/cis4607,https://www.youtube.com/channel/UCuZurGNa2j5dLLE3HOlZM4A,https://twitter.com/cis4607?lang=en,https://www.facebook.com/BeckerRobotics4607/,https://www.instagram.com/cis_4607robotics/?hl=en,https://www.thebluealliance.com/team/4607
+4623,Flyer Robotics,NA,NA,https://twitter.com/flyerrobotics,https://www.facebook.com/LittleFallsRobotics/,NA,https://www.thebluealliance.com/team/4623
+4624,Rebel Alliance,https://owatonna4624.wixsite.com/4624,NA,https://twitter.com/owatonna4624,https://www.facebook.com/First-Robotics-Owatonna-212297038900626/?fref=ts,https://www.instagram.com/owatonna4624/,https://www.thebluealliance.com/team/4624
+4632,Monty-Pythons,https://montipythons.wixsite.com/website,NA,https://twitter.com/montipythons?lang=en,NA,NA,https://www.thebluealliance.com/team/4632
+4648,Techno-Tech,http://technotechrobotics.com/technotech/,NA,https://twitter.com/technotech4648,NA,NA,https://www.thebluealliance.com/team/4648
+4656,Rock Solid Robotics,http://twoharborsrobotics.com/,NA,NA,https://www.facebook.com/RockSolid4656/,https://www.instagram.com/rocksolid4656/,https://www.thebluealliance.com/team/4656
+4663,Cyber Tigers,NA,NA,https://twitter.com/cybertigers4663?lang=en,NA,https://www.instagram.com/cybertigers4663/,https://www.thebluealliance.com/team/4663
+4664,Butler Bots,NA,NA,https://twitter.com/frc4664,NA,NA,https://www.thebluealliance.com/team/4664
+4665,Predators,NA,NA,https://twitter.com/gslpredators,https://www.facebook.com/GSL4665/,NA,https://www.thebluealliance.com/team/4665
+4674,RoboJacks,https://www.robojacks4674.org/,https://www.youtube.com/channel/UCx7dMM9pkVaiNabKnmUBGgg,,https://www.facebook.com/team4674,https://www.instagram.com/robo.jacks/,https://www.thebluealliance.com/team/4674
+4693,Axiomatic Aftermath,https://sites.google.com/rockford.k12.mn.us/waltersl/robotics,NA,NA,NA,NA,https://www.thebluealliance.com/team/4693
+4703,Menahga Gigabot$,NA,NA,NA,NA,NA,https://www.thebluealliance.com/team/4703
+4728,Rocori Rench Reckers,https://frc4728.wixsite.com/first,NA,https://twitter.com/robotics4728,https://www.facebook.com/RocoriRobotics/?ref=bookmarks,NA,https://www.thebluealliance.com/team/4728
+4741,WingNuts,NA,NA,https://twitter.com/frc4741rvhs?lang=en,https://www.facebook.com/pages/category/Youth-Organization/4741-Wingnuts-2435090523197275/,NA,https://www.thebluealliance.com/team/4741
+4778,Stormbots,https://sites.google.com/view/chanrobotics,https://www.youtube.com/channel/UCBmJmrtKRYjOS4TM1LlzEUw,https://twitter.com/chanrobotics,NA,https://www.instagram.com/chanrobotics/,https://www.thebluealliance.com/team/4778
+4845,Lion's Pride,NA,NA,https://twitter.com/frc4845,https://www.facebook.com/LakeviewRobotics/,https://www.instagram.com/frc4845/,https://www.thebluealliance.com/team/4845
+4859,The CyBears,https://sites.google.com/byron.k12.mn.us/byronrobotics,NA,https://twitter.com/byronrobotics?lang=en,https://www.facebook.com/ByronRobotics/,https://www.instagram.com/byron_cybears4859/?hl=en,https://www.thebluealliance.com/team/4859
+5143,GRG Raw Steel,NA,NA,NA,NA,NA,https://www.thebluealliance.com/team/5143
+5172,Gators,https://5172gators.org/,https://www.youtube.com/user/gmrrobotics,https://twitter.com/gmrrobotics,https://facebook.com/5172gators,https://www.instagram.com/gatorrobotics_5172/,https://www.thebluealliance.com/team/5172
+5232,Talons,NA,https://www.youtube.com/channel/UCUiEHgqclFZZ6td4ebNIVbw,NA,https://www.facebook.com/HermantownTalons5232/,NA,https://www.thebluealliance.com/team/5232
+5253,Bigfork Backwoods Bots,NA,NA,NA,NA,NA,https://www.thebluealliance.com/team/5253
+5271,Open Circuits,https://opencircuits.weebly.com/,NA,https://twitter.com/owlopencircuits?lang=en,NA,NA,https://www.thebluealliance.com/team/5271
+5275,T.I.M.E. Bots,https://timebots5275.com/,https://www.youtube.com/channel/UCb_E6_67T-BqZU3DlorhrCA,https://twitter.com/timebots5275,https://www.facebook.com/NewPragueTIMEBots5275FRC/,NA,https://www.thebluealliance.com/team/5275
+5278,Los Clasicos,NA,NA,NA,https://www.facebook.com/los.clasicos.5278,https://www.instagram.com/los.clasicos5278/,https://www.thebluealliance.com/team/5278
+5290,Mechanical Howl,NA,NA,https://twitter.com/team5290?lang=en,https://www.facebook.com/Team5290/,NA,https://www.thebluealliance.com/team/5290
+5299,Winger Tech,https://wingertech5299.wordpress.com/,NA,NA,https://www.facebook.com/pages/category/Community/Winger-Tech-5299-559642941071055/,NA,https://www.thebluealliance.com/team/5299
+5339,Hurricanes,NA,NA,NA,https://www.facebook.com/FRCteam5339/,NA,https://www.thebluealliance.com/team/5339
+5340,FAIRmingers,http://www.fairmingos.com/,NA,https://twitter.com/fairmingos,NA,NA,https://www.thebluealliance.com/team/5340
+5348,Charger Robotics,NA,https://www.youtube.com/channel/UCedHYi9jrupQBTPITDVxzog,NA,NA,https://www.instagram.com/frc5348/?hl=en,https://www.thebluealliance.com/team/5348
+5434,Falcon Robotics,NA,https://www.youtube.com/channel/UCM7EwJgWRUiafbFKZm0TQGQ,https://twitter.com/falcon_robotics,https://www.facebook.com/Falcon.Robotics/,https://www.instagram.com/faribault.falcon.robotics/?hl=en,https://www.thebluealliance.com/team/5434
+5464,Bluejacket Robotics,NA,NA,NA,https://www.facebook.com/BluejacketRobotics/,https://www.instagram.com/bluejacketsteam5464/,https://www.thebluealliance.com/team/5464
+5541,Shakopee Robotics,NA,https://www.youtube.com/channel/UCNu52ijqs5JepFZdRavFj2g/videos?view=0&sort=da&flow=grid,https://twitter.com/shakorobotics?lang=en,https://www.facebook.com/Shakopee-Robotics-831451413567234/,https://www.instagram.com/saber_robotics/,https://www.thebluealliance.com/team/5541
+5542,RoboHerd,https://www.roboherd5542.com/,NA,NA,https://www.facebook.com/RoboHerd5542/,https://www.instagram.com/buffalo_robotics/?hl=en,https://www.thebluealliance.com/team/5542
+5626,Nu-matic Ninjas,https://numaticninjas.wixsite.com/centralrobotics5626,NA,https://twitter.com/ninjas5626?lang=en,https://www.facebook.com/ninjas5626/,https://www.instagram.com/ninjas5626/?hl=af,https://www.thebluealliance.com/team/5626
+5637,Titanium Polars,NA,NA,NA,NA,NA,https://www.thebluealliance.com/team/5637
+5638,LQPV Robotics,NA,NA,https://twitter.com/frc5638,NA,https://www.instagram.com/frc5638/?hl=en,https://www.thebluealliance.com/team/5638
+5653,Iron Mosquitos,https://ironmos5653.wixsite.com/web-studio-blog,NA,https://twitter.com/frc5653?lang=en,https://www.facebook.com/Iron-Mosquitoes-FRC-5653-109096880611622/?ref=page_internal,NA,https://www.thebluealliance.com/team/5653
+5658,STORMBOTICS,NA,NA,NA,NA,NA,https://www.thebluealliance.com/team/5658
+5690,SubZero Robotics,https://subzerorobotics.wordpress.com/,NA,https://twitter.com/subzerorobotics,https://www.facebook.com/SubZeroRobotics5690/,NA,https://www.thebluealliance.com/team/5690
+5720,Jagobotics,NA,NA,https://twitter.com/jagobotics5720,NA,NA,https://www.thebluealliance.com/team/5720
+5913,Patriotics,https://patriotics186.weebly.com/,NA,NA,https://www.facebook.com/patriotics186,NA,https://www.thebluealliance.com/team/5913
+5914,Robotic Warriors,https://www.7rrc.org/caledonia-1,NA,https://twitter.com/frc5914,https://www.facebook.com/CaledoniaRobotics/,NA,https://www.thebluealliance.com/team/5914
+5929,The Marauders,NA,NA,NA,https://www.facebook.com/pages/category/Just-For-Fun/The-Marauders-LPA-Team-5929-339821589760175/,NA,https://www.thebluealliance.com/team/5929
+5991,Chargers,NA,NA,NA,NA,NA,https://www.thebluealliance.com/team/5991
+5998,The Chillbots,NA,NA,NA,https://www.facebook.com/thechillbotsfrcteam5998,NA,https://www.thebluealliance.com/team/5998
+5999,Byte Force,NA,NA,https://twitter.com/Byte_Force5999,https://www.facebook.com/byte.force.5,https://www.instagram.com/milaca_byte_force/,https://www.thebluealliance.com/team/5999
+6022,Wrench Warmers,https://www.wrenchwarmers6022.com/,NA,https://twitter.com/frc6022?lang=en,https://www.facebook.com/wrenchwarmers/,https://www.instagram.com/p/Buzc9_QlJl4/,https://www.thebluealliance.com/team/6022
+6044,Circuit Breakers,NA,NA,https://mobile.twitter.com/frc6044,https://www.facebook.com/frc6044/,NA,https://www.thebluealliance.com/team/6044
+6045,Sabre Robotics,https://www.frc6045.org/,NA,https://twitter.com/frc6045,https://www.facebook.com/SabreRobotics/,NA,https://www.thebluealliance.com/team/6045
+6047,Proctor Frostbyte,https://frostbyte.club/,NA,https://twitter.com/phsfrostbyte?lang=en,NA,NA,https://www.thebluealliance.com/team/6047
+6132,Iron Rangers,https://rangerrobotics.weebly.com/,https://www.youtube.com/channel/UCsAq_VMHYMtDjIzkwz01sZg,https://twitter.com/Ranger_Robotics,NA,NA,https://www.thebluealliance.com/team/6132
+6146,Blackjacks,NA,NA,https://twitter.com/DBHSRobotics,https://www.facebook.com/dawsonboydrobotics/,https://www.instagram.com/dbhsrobotics/,https://www.thebluealliance.com/team/6146
+6147,Tonkabots,NA,NA,https://twitter.com/tonka_bots?lang=en,NA,NA,https://www.thebluealliance.com/team/6147
+6160,Bombatrons,https://bombatrons.weebly.com/,NA,https://twitter.com/bombatrons,https://www.facebook.com/bombatrons/,https://www.instagram.com/bombatrons/,https://www.thebluealliance.com/team/6160
+6475,EVW Mystery Machine,https://sites.google.com/evw.k12.mn.us/6175-mm-robotics,NA,https://twitter.com/6175machine,NA,NA,https://www.thebluealliance.com/team/6475
+6217,Bomb-Botz,NA,NA,https://twitter.com/6217cfhs,https://www.facebook.com/cfhs6217,https://www.instagram.com/cfhs_6217/,https://www.thebluealliance.com/team/6217
+6453,Bog Bots,https://www.bogbots6453.org/,NA,NA,https://www.facebook.com/bogbots6453/,https://www.instagram.com/kelliherbogbots_6453/,https://www.thebluealliance.com/team/6453
+6628,KMS Botkickers,NA,NA,NA,NA,NA,https://www.thebluealliance.com/team/6628
+6707,RCW Jaguar Robosapiens,NA,NA,NA,NA,NA,https://www.thebluealliance.com/team/6707
+6709,Spudinc,https://biglakerobotics.wixsite.com/mysite,NA,https://twitter.com/spudinc6709,https://www.facebook.com/spudinc6709/,https://www.instagram.com/biglakerobotics/,https://www.thebluealliance.com/team/6709
+6749,tERAbytes,NA,NA,https://twitter.com/team6749,NA,NA,https://www.thebluealliance.com/team/6749
+6758,Otternauts,NA,NA,https://twitter.com/kmrobotics?lang=en,https://www.facebook.com/kmrobotics2017,NA,https://www.thebluealliance.com/team/6758
+6912,InterGalactic Transformers,NA,NA,NA,NA,NA,https://www.thebluealliance.com/team/6912
+7019,TechNoLogic,NA,NA,NA,NA,NA,https://www.thebluealliance.com/team/7019
+7028,Binary Battalion,http://7028robotics.com/,https://www.youtube.com/channel/UCTrd72vnpDdWQ83zk3-plHw,https://twitter.com/stma_robotics?lang=en,https://www.facebook.com/STMARoboticsClub/,NA,https://www.thebluealliance.com/team/7028
+7038,Pizza Pi's,NA,NA,NA,NA,NA,https://www.thebluealliance.com/team/7038
+7041,Doomsday Dogs,NA,NA,https://twitter.com/doomsdaydogs?lang=en,https://www.facebook.com/doomsdaydogs7041/?ref=page_internal,https://www.instagram.com/carlton.robotics/?hl=en,https://www.thebluealliance.com/team/7041
+7068,Mechanical Masterminds,https://www.stfrancisrobotics.org/,NA,NA,https://www.facebook.com/SFHS7068Robotics/,https://www.instagram.com/mechanical.masterminds/,https://www.thebluealliance.com/team/7068
+7180,Wellstone Lions,NA,NA,NA,NA,NA,https://www.thebluealliance.com/team/7180
+7235,Red Lake Ogishidaag,NA,NA,NA,https://www.facebook.com/RLHS-Team-7235-336773733475948/,NA,https://www.thebluealliance.com/team/7235
+7257,Sauk Centre Robotics,NA,NA,https://twitter.com/team7257,NA,NA,https://www.thebluealliance.com/team/7257
+7258,Hiawatha Collegiate,NA,NA,NA,NA,NA,https://www.thebluealliance.com/team/7258
+7273,ZooM Robotics,https://zmrobotics.wixsite.com/7273,NA,https://twitter.com/zmrobotics,https://www.facebook.com/ZooMRobotics7273/?__tn__=%2Cd%2CP-R&eid=ARAsrB45IOa3f6Ds43I4ffnHGIiucJttIecY_SfcXm1Hzf7RrXq2f6ey1e5ephtteWnoSGlqCFLmpbeE,https://www.instagram.com/zmrobotics/,https://www.thebluealliance.com/team/7273
+7311,Boring Robots,https://boring-robotics.neocities.org/,NA,NA,NA,NA,https://www.thebluealliance.com/team/7311
+7432,NOS,NA,NA,https://twitter.com/frcnos,NA,https://www.instagram.com/frc7432/?hl=en,https://www.thebluealliance.com/team/7432
+7530,Brotherhood of Steel,https://wmrobotics7530.wixsite.com/7530,NA,https://twitter.com/RoboticsWm,https://www.facebook.com/watertownmayerschooldistrict/,https://www.instagram.com/wm.robotics/,https://www.thebluealliance.com/team/7530
+7541,Maple River Robotics,NA,NA,NA,https://www.facebook.com/mapleriverrobotics,NA,https://www.thebluealliance.com/team/7541
+7677,Brodacious Bulldogs,NA,NA,NA,NA,NA,https://www.thebluealliance.com/team/7677
+7797,Cloquet's Ripsaw Robotics,https://ripsawrobotics.weebly.com/,NA,https://twitter.com/ripsawr,https://www.facebook.com/groups/486187188458178/?ref=group_header,https://www.instagram.com/ripsawrobotics/,https://www.thebluealliance.com/team/7797
+7849,Chi You's G3AR T3K3,NA,NA,https://twitter.com/7849ers,NA,NA,https://www.thebluealliance.com/team/7849
+7850,C.A.R.D.S,NA,NA,NA,https://www.facebook.com/Robotics.CRHS/,NA,https://www.thebluealliance.com/team/7850
+7858,Warriors,http://64.8.149.185:82/index.html,NA,NA,https://www.facebook.com/warriorrobotics7858,https://www.instagram.com/warrior_robotics7858/,https://www.thebluealliance.com/team/7858
+7864,North Woods Robotics,NA,NA,NA,NA,NA,https://www.thebluealliance.com/team/7864
+7875,MNIC Robotics,NA,NA,https://twitter.com/7875mnic,NA,NA,https://www.thebluealliance.com/team/7875
+7893,Maple Lake High School,NA,NA,NA,NA,NA,https://www.thebluealliance.com/team/7893
+8234,Panthinators,NA,NA,NA,https://www.facebook.com/slprobotics/,NA,https://www.thebluealliance.com/team/8234
+8298,Mighty Morphing Banana Slugs,http://frc8298.com/,NA,NA,NA,https://www.instagram.com/luvernerobotics/,https://www.thebluealliance.com/team/8298
+8347,Broken Eagles,NA,NA,NA,NA,NA,https://www.thebluealliance.com/team/8347
+8355,Melanin Minds,NA,NA,NA,NA,https://www.instagram.com/mmelaninminds/,https://www.thebluealliance.com/team/8355
+8372,HCN Storm,NA,NA,NA,NA,NA,https://www.thebluealliance.com/team/8372
+8409,Kato Coyote's,NA,NA,NA,NA,NA,https://www.thebluealliance.com/team/8409
+8412,Battle Lake Schools,NA,NA,NA,NA,NA,https://www.thebluealliance.com/team/8412
+8416,Wolfbotics,NA,NA,NA,NA,NA,https://www.thebluealliance.com/team/8416
+8422,Pillager High School,NA,NA,NA,NA,NA,https://www.thebluealliance.com/team/8422
+8516,Wired Up,NA,NA,NA,NA,NA,https://www.thebluealliance.com/team/8516
+8887,West Central Area Knights 22,NA,NA,NA,NA,NA,https://www.thebluealliance.com/team/8887
+8878,ArrowBot,NA,NA,NA,NA,NA,https://www.thebluealliance.com/team/8878
+8787,Mavericks,NA,NA,NA,NA,NA,https://www.thebluealliance.com/team/8787
+8836,Wayne Enterprises Inc.,NA,NA,NA,NA,NA,https://www.thebluealliance.com/team/8836

--- a/matches.html
+++ b/matches.html
@@ -17,16 +17,16 @@ permalink: /matches/
           <div class="captionMatch">Semi-Finals Match 2</div>
           <div class="captionMatch">Red Alliance</div>
         </div>
-        <div class="col"><iframe class="video" src="https://www.youtube.com/embed/gvLyR1-hN7I" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>
+        <div class="col verticalLine"><iframe class="video" src="https://www.youtube.com/embed/gvLyR1-hN7I" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>
     </div>
 
     <div class="row">
       <div class="col my-auto">
         <div class="captionMatchComp">Lake Superior Regional</div>
-        <div class="captionMatch">Quarter=Finals Match 2</div>
+        <div class="captionMatch">Quarter-Finals Match 2</div>
         <div class="captionMatch">Red Alliance</div>
       </div>
-      <div class="col"><iframe class="video" src="https://www.youtube.com/embed/kirFwqO6Rp4" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>
+      <div class="col verticalLine"><iframe class="video" src="https://www.youtube.com/embed/kirFwqO6Rp4" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>
     </div>
     <div class="row">
       <div class="col my-auto">
@@ -34,18 +34,18 @@ permalink: /matches/
         <div class="captionMatch">Quarter-Finals Match 2</div>
         <div class="captionMatch">Red Alliance</div>
       </div>
-      <div class="col"><iframe class="video" src="https://www.youtube.com/embed/KXOLDJFnnr4" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>
+      <div class="col verticalLine"><iframe class="video" src="https://www.youtube.com/embed/KXOLDJFnnr4" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>
     </div>
     <div class="row center padding">
       <p><a href="https://www.thebluealliance.com/team/2052/2022" target=_blank">All 2022 Matches</a></p>
     </div>
   </div>
-   
+
   <div class="text-center col-lg-6 col-md-12">
       <a href="/history/2020infiniterecharge/"><h2 class="kk maroon-bg gold text-center pt-2 pb-2 mt-4">2020 Infinite Recharge</h2></a>
       <div class="row">
         <div class="col"><iframe class="video" src="https://www.youtube.com/embed/yUYm47vtNWk" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>
-        <div class="col my-auto verticalLine">
+        <div class="col my-auto">
           <div class="captionMatchComp">Northern Lights Regional</div>
           <div class="captionMatch">Semi-Finals Match 3</div>
           <div class="captionMatch">Red Alliance</div>
@@ -53,7 +53,7 @@ permalink: /matches/
       </div>
       <div class="row">
         <div class="col"><iframe class="video" src="https://www.youtube.com/embed/sWaU0z1rnhg" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>
-        <div class="col my-auto verticalLine">
+        <div class="col my-auto">
           <div class="captionMatchComp">Northern Lights Regional</div>
           <div class="captionMatch">Finals Match 1</div>
           <div class="captionMatch">Red Alliance</div>
@@ -61,7 +61,7 @@ permalink: /matches/
       </div>
       <div class="row">
         <div class="col"><iframe class="video" src="https://www.youtube.com/embed/TzjrXHuHlzY" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>
-        <div class="col my-auto verticalLine">
+        <div class="col my-auto">
           <div class="captionMatchComp">Northern Lights Regional</div>
           <div class="captionMatch">Finals Match 2</div>
           <div class="captionMatch">Red Alliance</div>

--- a/mnteams.html
+++ b/mnteams.html
@@ -186,34 +186,34 @@ For screen sizes larger than sm
         {% if def.Website == "NA" %}
           <td class="mnteamsList text-center" style="font-size: 18px; background: #{{ col }};">NA</td>
         {% else %}
-          <td class="mnteamsList text-center" style="background: #{{ col }};"><a href="{{def.Website}}"><i class="fas fa-align-center"></i></a></td>
+          <td class="mnteamsList text-center" style="background: #{{ col }};"><a target="_blank" href="{{def.Website}}"><i class="fas fa-align-center"></i></a></td>
         {% endif %}
 
         {% if def.Twitter == "NA" %}
           <td class="mnteamsList text-center" style="font-size: 18px; background: #{{ col }};">NA</td>
         {% else %}
-          <td class="mnteamsList text-center" style="background: #{{ col }};"><a href="{{def.Twitter}}"><i class="fab fa-twitter-square"></i></a></td>
+          <td class="mnteamsList text-center" style="background: #{{ col }};"><a target="_blank" href="{{def.Twitter}}"><i class="fab fa-twitter-square"></i></a></td>
         {% endif %}
 
         {% if def.Facebook == "NA" %}
           <td class="mnteamsList text-center" style="font-size: 18px; background: #{{ col }};">NA</td>
         {% else %}
-          <td class="mnteamsList text-center" style="background: #{{ col }};"><a href="{{def.Facebook}}"><i class="fab fa-facebook-square"></i></a></td>
+          <td class="mnteamsList text-center" style="background: #{{ col }};"><a target="_blank" href="{{def.Facebook}}"><i class="fab fa-facebook-square"></i></a></td>
         {% endif %}
 
         {% if def.Instagram == "NA" %}
           <td class="mnteamsList text-center" style="font-size: 18px; background: #{{ col }};">NA</td>
         {% else %}
-          <td class="mnteamsList text-center" style="background: #{{ col }};"><a href="{{def.Instagram}}"><i class="fab fa-instagram"></i></a></td>
+          <td class="mnteamsList text-center" style="background: #{{ col }};"><a target="_blank" href="{{def.Instagram}}"><i class="fab fa-instagram"></i></a></td>
         {% endif %}
 
         {% if def.Youtube == "NA" %}
           <td class="mnteamsList text-center" style="font-size: 18px; background: #{{ col }};">NA</td>
         {% else %}
-          <td class="mnteamsList text-center" style="background: #{{ col }};"><a href="{{def.Youtube}}"><i class="fab fa-youtube-square"></i></a></td>
+          <td class="mnteamsList text-center" style="background: #{{ col }};"><a target="_blank" href="{{def.Youtube}}"><i class="fab fa-youtube-square"></i></a></td>
         {% endif %}
 
-          <td class="mnteamsList text-center" style="background: #{{ col }};"><a href="{{def.TBA}}"><i class="fas fa-chess-rook"></i></a></td>
+          <td class="mnteamsList text-center" style="background: #{{ col }};"><a target="_blank" href="{{def.TBA}}"><i class="fas fa-chess-rook"></i></a></td>
       </tr>
     {% endfor %}
 

--- a/sponsors.html
+++ b/sponsors.html
@@ -26,35 +26,36 @@ permalink: /sponsors/
               <i class="fas fa-crown"></i> KING LEVEL
           </div>
           <div class="card-body">
-            <div class="justify-content-center sponsor-row">
-              <img src="/assets/images/sponsors/Groves.jpg" class="mx-auto d-block img-fluid"/>
-            </a>
-          </div>
-          <div class="justify-content-center sponsor-row">
-            <a href="http://Medtronic.com" target="_blank">
-              <img src="/assets/images/sponsors/Medtronic.png" class="mx-auto d-block img-fluid"/>
-            </a>
-          </div>
-            <div class="justify-content-center sponsor-row">
-              <a href="https://www.ebenezercares.org/" target="_blank">
-                <img src="/assets/images/sponsors/Ebenezer.png" class="mx-auto d-block img-fluid"/>
+              <div class="justify-content-center sponsor-row">
+                <a href="http://groves-foundation.com/" target="_blank">
+                <img src="/assets/images/sponsors/Groves.jpg" class="mx-auto d-block img-fluid"/>
               </a>
             </div>
             <div class="justify-content-center sponsor-row">
-              <a href="https://www.lionsclubs.org/en/start-our-approach/club-locator/details?id=2808 target="_blank">
-                <img src="/assets/images/sponsors/Lions Club International.png" class="mx-auto d-block img-fluid"/>
+              <a href="http://Medtronic.com" target="_blank">
+                <img src="/assets/images/sponsors/Medtronic.png" class="mx-auto d-block img-fluid"/>
               </a>
             </div>
-            <div class="justify-content-center sponsor-row">
-              <a href="http://QONQR.com" target="_blank">
-                <img src="/assets/images/sponsors/QONQR.png" class="mx-auto d-block img-fluid"/>
-              </a>
+              <div class="justify-content-center sponsor-row">
+                <a href="https://www.ebenezercares.org/" target="_blank">
+                  <img src="/assets/images/sponsors/Ebenezer.png" class="mx-auto d-block img-fluid"/>
+                </a>
+              </div>
+              <div class="justify-content-center sponsor-row">
+                <a href="https://www.lionsclubs.org/en/start-our-approach/club-locator/details?id=2808 target="_blank">
+                  <img src="/assets/images/sponsors/Lions Club International.png" class="mx-auto d-block img-fluid"/>
+                </a>
+              </div>
+              <div class="justify-content-center sponsor-row">
+                <a href="http://QONQR.com" target="_blank">
+                  <img src="/assets/images/sponsors/QONQR.png" class="mx-auto d-block img-fluid"/>
+                </a>
+              </div>
+              <div class="justify-content-center sponsor-row">
+                <a href="https://www.moundsviewschools.org/irondale" target="_blank">
+                  <img src="/assets/images/sponsors/Irondale.jpg" class="mx-auto d-block img-fluid"/>
+                </a>
             </div>
-            <div class="justify-content-center sponsor-row">
-              <a href="https://www.moundsviewschools.org/irondale" target="_blank">
-                <img src="/assets/images/sponsors/Irondale.jpg" class="mx-auto d-block img-fluid"/>
-              </a>
-          </div>
           </div>
         </div>
 
@@ -77,7 +78,7 @@ permalink: /sponsors/
           </div>
             <div class="card-body">
               <div class="justify-content-center sponsor-row">
-                <a href="www.fedtech.com" target="_blank">
+                <a href="https://www.fedtech.com" target="_blank">
                 <img src="/assets/images/sponsors/FedTech.png" class="mx-auto d-block img-fluid"/>
                 </a>
               </div>
@@ -89,7 +90,7 @@ permalink: /sponsors/
               <div class="justify-content-center sponsor-row">
                 <a href="https://www.dominos.com/en/" target="_blank">
                 <img src="/assets/images/sponsors/dominos.png" class="mx-auto d-block img-fluid"/>
-                </a> 
+                </a>
               </div>
               <div class="justify-content-center sponsor-row">
                 <a href="https://www.softlakesolutions.com/" target="_blank">
@@ -122,7 +123,7 @@ permalink: /sponsors/
               <div class="justify-content-center sponsor-row">
                 <a href="https://www.arise-op.com/home.html" target="_blank">
                 <img src="/assets/images/sponsors/Arise_logo.jpg" class="mx-auto d-block img-fluid"/>
-                </a> 
+                </a>
               </div>
               <div class="justify-content-center sponsor-row">
                 <a href="https://amywakem.com/" target="_blank">
@@ -198,7 +199,7 @@ permalink: /sponsors/
           <p>
             KnightKrawler Robotics is not an elite program for rich kids, as some might think.
             Not all our students have the financial means to participate in after-school activities.
-            That is why KnightKrawler does not charge any fees for students on free or reduced lunch. 
+            That is why KnightKrawler does not charge any fees for students on free or reduced lunch.
             Travel fees for all students are optional to all competitions in the midwest and financial travel assistance is
             available for travel to World Championships in Houston, Texas this year.
             We uses sponsorship dollars every year to cover the travel fees


### PR DESCRIPTION
Sponsor link for FedTech wasn't working, so it got fixed to go to the the FedTech link. There was no link to Grover Foundations, now there is.
TBA Links in MN Team list didn't work because TBA updated their links, it is now updated so they work. Also all the links in MN Teams list go to a new tab. 
Some lines in Match playlist were moved to the middle where they should be. 